### PR TITLE
Adds API Manifest validation

### DIFF
--- a/src/benchmark/benchmark.csproj
+++ b/src/benchmark/benchmark.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\lib\apimanifest.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Benchmarkdotnet" Version="0.13.5" />
+    <PackageReference Include="Benchmarkdotnet" Version="0.13.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/benchmark/perf.cs
+++ b/src/benchmark/perf.cs
@@ -1,17 +1,19 @@
-using System.Text.Json;
 using BenchmarkDotNet.Attributes;
 using Microsoft.OpenApi.ApiManifest;
+using System.Text.Json;
 
 [MemoryDiagnoser] // we need to enable it in explicit way
-public class Perf {
-   
+public class Perf
+{
+
     private MemoryStream? apiManifestStream;
     private JsonSerializerOptions? autoSerializationOptions;
-    
+
     [GlobalSetup]
     public void GlobalSetup()
     {
-        autoSerializationOptions = new JsonSerializerOptions() {
+        autoSerializationOptions = new JsonSerializerOptions()
+        {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
@@ -51,7 +53,7 @@ public class Perf {
     ]
 }
         ";
-        var writer = new StreamWriter(apiManifestStream);
+        StreamWriter writer = new StreamWriter(apiManifestStream);
         writer.Write(json);
         writer.Flush();
 
@@ -60,10 +62,10 @@ public class Perf {
     [Benchmark]
     public void DeserializeApiManifest()
     {
-       // Read string from stream
+        // Read string from stream
         apiManifestStream!.Position = 0;
-        var doc = JsonDocument.Parse(apiManifestStream);
-        var apiManifest = ApiManifestDocument.Load(doc.RootElement);
+        JsonDocument doc = JsonDocument.Parse(apiManifestStream);
+        _ = ApiManifestDocument.Load(doc.RootElement);
     }
 
 
@@ -71,15 +73,15 @@ public class Perf {
     public void AutoDeserializeApiManifest()
     {
         apiManifestStream!.Position = 0;
-        var apiManifest = JsonSerializer.Deserialize<ApiManifestDocument>(apiManifestStream, autoSerializationOptions);
+        _ = JsonSerializer.Deserialize<ApiManifestDocument>(apiManifestStream, autoSerializationOptions);
     }
 
     [Benchmark]
     public void AutoDeserializeApiManifestFromRootElement()
     {
         apiManifestStream!.Position = 0;
-        var doc = JsonDocument.Parse(apiManifestStream);
-        var apiManifest = JsonSerializer.Deserialize<ApiManifestDocument>(doc.RootElement, autoSerializationOptions);
+        JsonDocument doc = JsonDocument.Parse(apiManifestStream);
+        _ = JsonSerializer.Deserialize<ApiManifestDocument>(doc.RootElement, autoSerializationOptions);
     }
 
 }

--- a/src/lib/AccessRequest.cs
+++ b/src/lib/AccessRequest.cs
@@ -5,8 +5,9 @@ namespace Microsoft.OpenApi.ApiManifest;
 
 public class AccessRequest
 {
-
+    // TODO: Add validation. Type is required and is unique for the described API according to RAR - https://www.rfc-editor.org/rfc/rfc9396.
     private const string TypeProperty = "type";
+    // TODO: Rename to 'actions' to match RAR spec.
     private const string ContentProperty = "content";
 
     public string? Type { get; set; }

--- a/src/lib/ApiDependency.cs
+++ b/src/lib/ApiDependency.cs
@@ -6,14 +6,15 @@ public class ApiDependency
     public string? ApiDescriptionUrl { get; set; }
     public string? ApiDescriptionVersion { get; set; }
     public string? ApiDeploymentBaseUrl { get; set; }
-    public Auth? Auth { get; set; }
+    public AuthorizationRequirements? AuthorizationRequirements { get; set; }
     public List<Request> Requests { get; set; } = new List<Request>();
+    // TODO: Settle on a name. Extensions vs extensibility as per https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html.
     public Extensions? Extensions { get; set; }
 
     private const string ApiDescriptionUrlProperty = "apiDescriptionUrl";
     private const string ApiDescriptionVersionProperty = "apiDescriptionVersion";
     private const string ApiDeploymentBaseUrlProperty = "apiDeploymentBaseUrl";
-    private const string AuthProperty = "auth";
+    private const string AuthorizationRequirementsProperty = "authorizationRequirements";
     private const string RequestsProperty = "requests";
     private const string ExtensionsProperty = "extensions";
 
@@ -26,10 +27,10 @@ public class ApiDependency
         if (!string.IsNullOrWhiteSpace(ApiDescriptionVersion)) writer.WriteString(ApiDescriptionVersionProperty, ApiDescriptionVersion);
         if (!string.IsNullOrWhiteSpace(ApiDeploymentBaseUrl)) writer.WriteString(ApiDeploymentBaseUrlProperty, ApiDeploymentBaseUrl);
 
-        if (Auth != null)
+        if (AuthorizationRequirements != null)
         {
-            writer.WritePropertyName(AuthProperty);
-            Auth?.Write(writer);
+            writer.WritePropertyName(AuthorizationRequirementsProperty);
+            AuthorizationRequirements?.Write(writer);
         }
 
         if (Requests.Count > 0)
@@ -51,13 +52,14 @@ public class ApiDependency
 
         writer.WriteEndObject();
     }
+
     // Fixed fieldmap for ApiDependency
     private static readonly FixedFieldMap<ApiDependency> handlers = new()
     {
         { ApiDescriptionUrlProperty, (o,v) => {o.ApiDescriptionUrl = v.GetString();  } },
         { ApiDescriptionVersionProperty, (o,v) => {o.ApiDescriptionVersion = v.GetString();  } },
         { ApiDeploymentBaseUrlProperty, (o,v) => {o.ApiDeploymentBaseUrl = v.GetString();  } },
-        { AuthProperty, (o,v) => {o.Auth = Auth.Load(v);  } },
+        { AuthorizationRequirementsProperty, (o,v) => {o.AuthorizationRequirements = AuthorizationRequirements.Load(v);  } },
         { RequestsProperty, (o,v) => {o.Requests = ParsingHelpers.GetList(v, Request.Load);  } },
         { ExtensionsProperty, (o,v) => {o.Extensions = Extensions.Load(v);  } }
     };

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -5,7 +5,6 @@ namespace Microsoft.OpenApi.ApiManifest;
 public class ApiManifestDocument
 {
     public Publisher? Publisher { get; set; }
-    // TODO: Add reader and writer for ApplicationName.
     public string? ApplicationName { get; set; }
     public ApiDependencies ApiDependencies { get; set; } = new ApiDependencies();
     public Extensions Extensions { get; set; } = new Extensions();

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -5,54 +5,82 @@ namespace Microsoft.OpenApi.ApiManifest;
 public class ApiManifestDocument
 {
     public Publisher? Publisher { get; set; }
+    // TODO: Add reader and writer for ApplicationName.
+    public string? ApplicationName { get; set; }
     public ApiDependencies ApiDependencies { get; set; } = new ApiDependencies();
     public Extensions Extensions { get; set; } = new Extensions();
 
     private const string PublisherProperty = "publisher";
+    private const string ApplicationNameProperty = "applicationName";
     private const string ApiDependenciesProperty = "apiDependencies";
     private const string ExtensionsProperty = "extensions";
 
-    public ApiManifestDocument()
+    public ApiManifestDocument(string applicationName)
     {
-        if (Publisher != null) {
-            if (string.IsNullOrEmpty(Publisher.ContactEmail)) throw new ArgumentNullException(nameof(Publisher.ContactEmail));
-        }
+        Validate(applicationName);
+
+        ApplicationName = applicationName;
+    }
+
+    public ApiManifestDocument(JsonElement value)
+    {
+        ParsingHelpers.ParseMap(value, this, handlers);
+
+        Validate(ApplicationName);
     }
 
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
+        Validate(ApplicationName);
+
         writer.WriteStartObject();
 
-        if (Publisher != null) writer.WritePropertyName(PublisherProperty);
-        Publisher?.Write(writer);
+        writer.WriteString(ApplicationNameProperty, ApplicationName);
 
-        if (ApiDependencies.Count > 0) writer.WritePropertyName(ApiDependenciesProperty);
-        writer.WriteStartObject();
-        foreach (var apiDependency in ApiDependencies)
+        if (Publisher != null)
         {
-            writer.WritePropertyName(apiDependency.Key);
-            apiDependency.Value.Write(writer);
+            writer.WritePropertyName(PublisherProperty);
+            Publisher.Write(writer);
         }
-        writer.WriteEndObject();
 
-        if (Extensions.Count > 0) {
+        if (ApiDependencies.Any())
+        {
+            writer.WritePropertyName(ApiDependenciesProperty);
+            writer.WriteStartObject();
+            foreach (var apiDependency in ApiDependencies)
+            {
+                writer.WritePropertyName(apiDependency.Key);
+                apiDependency.Value.Write(writer);
+            }
+            writer.WriteEndObject();
+        }
+
+        if (Extensions.Any())
+        {
             writer.WritePropertyName(ExtensionsProperty);
             Extensions.Write(writer);
         }
 
         writer.WriteEndObject();
     }
+
     // Load method
     public static ApiManifestDocument Load(JsonElement value)
     {
-        var apiManifest = new ApiManifestDocument();
-        ParsingHelpers.ParseMap(value, apiManifest, handlers);
-        return apiManifest;
+        return new ApiManifestDocument(value);
     }
-    // Create fixed field map for ApiManifest
-    private static FixedFieldMap<ApiManifestDocument> handlers = new()
+
+    private static void Validate(string? applicationName)
     {
+        if (string.IsNullOrWhiteSpace(applicationName))
+            throw new ArgumentNullException(applicationName, String.Format(ErrorConstants.FieldIsRequired, "applicationName", "ApiManifest"));
+    }
+
+    // Create fixed field map for ApiManifest
+    private static readonly FixedFieldMap<ApiManifestDocument> handlers = new()
+    {
+        { ApplicationNameProperty, (o,v) => {o.ApplicationName = v.GetString(); } },
         { PublisherProperty, (o,v) => {o.Publisher = Publisher.Load(v);  } },
         { ApiDependenciesProperty, (o,v) => {o.ApiDependencies = new ApiDependencies(ParsingHelpers.GetMap(v, ApiDependency.Load));  } },
         { ExtensionsProperty, (o,v) => {o.Extensions = Extensions.Load(v);  } }

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -73,7 +73,7 @@ public class ApiManifestDocument
     private static void Validate(string? applicationName)
     {
         if (string.IsNullOrWhiteSpace(applicationName))
-            throw new ArgumentNullException(applicationName, String.Format(ErrorConstants.FieldIsRequired, "applicationName", "ApiManifest"));
+            throw new ArgumentNullException(applicationName, String.Format(ErrorMessage.FieldIsRequired, "applicationName", "ApiManifest"));
     }
 
     // Create fixed field map for ApiManifest

--- a/src/lib/AuthorizationRequirements.cs
+++ b/src/lib/AuthorizationRequirements.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Microsoft.OpenApi.ApiManifest;
 
-public class Auth
+public class AuthorizationRequirements
 {
     public string? ClientIdentifier { get; set; }
     public List<string>? AccessReference { get; set; }
@@ -11,16 +11,16 @@ public class Auth
     private const string ClientIdentifierProperty = "clientIdentifier";
     private const string AccessProperty = "access";
 
-    // Fixed fieldmap for Auth
-    private static FixedFieldMap<Auth> handlers = new()
+    // Fixed fieldmap for AuthorizationRequirements
+    private static readonly FixedFieldMap<AuthorizationRequirements> handlers = new()
     {
         { ClientIdentifierProperty, (o,v) => { o.ClientIdentifier = v.GetString();  } },
         { AccessProperty, (o,v) => { LoadAccessProperty(o, v); }}
     };
 
-    private static void LoadAccessProperty(Auth o, JsonElement v)
+    private static void LoadAccessProperty(AuthorizationRequirements o, JsonElement v)
     {
-        var content = v.EnumerateArray().FirstOrDefault();
+        JsonElement content = v.EnumerateArray().FirstOrDefault();
         if (content.ValueKind == JsonValueKind.String)
         {
             o.AccessReference = ParsingHelpers.GetListOfString(v);
@@ -44,12 +44,14 @@ public class Auth
             writer.WriteStartArray();
             if (AccessReference != null)
             {
-                foreach (var accessReference in AccessReference)
+                foreach (string accessReference in AccessReference)
                 {
                     writer.WriteStringValue(accessReference);
                 }
-            } else if (Access != null) {
-                foreach (var accessRequest in Access)
+            }
+            else if (Access != null)
+            {
+                foreach (AccessRequest accessRequest in Access)
                 {
                     accessRequest.Write(writer);
                 }
@@ -59,9 +61,9 @@ public class Auth
         writer.WriteEndObject();
     }
     // Load Method
-    internal static Auth Load(JsonElement value)
+    internal static AuthorizationRequirements Load(JsonElement value)
     {
-        var auth = new Auth();
+        var auth = new AuthorizationRequirements();
         ParsingHelpers.ParseMap(value, auth, handlers);
         return auth;
     }

--- a/src/lib/AuthorizationRequirements.cs
+++ b/src/lib/AuthorizationRequirements.cs
@@ -5,6 +5,7 @@ namespace Microsoft.OpenApi.ApiManifest;
 public class AuthorizationRequirements
 {
     public string? ClientIdentifier { get; set; }
+    // TODO: Confirm the need for AccessReference property. It is not present in the spec.
     public List<string>? AccessReference { get; set; }
     public List<AccessRequest>? Access { get; set; }
 

--- a/src/lib/Constants.cs
+++ b/src/lib/Constants.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.OpenApi.ApiManifest
+{
+    internal static class Constants
+    {
+        public static readonly TimeSpan DefaultRegexTimeout = TimeSpan.FromSeconds(5);
+    }
+
+    internal static class ErrorConstants
+    {
+        public static string FieldIsRequired = "'{0}' is a required property of '{1}'.";
+        public static string FieldIsNotValid = "'{0}' is not valid.";
+    }
+}

--- a/src/lib/Constants.cs
+++ b/src/lib/Constants.cs
@@ -5,7 +5,7 @@
         public static readonly TimeSpan DefaultRegexTimeout = TimeSpan.FromSeconds(5);
     }
 
-    internal static class ErrorConstants
+    internal static class ErrorMessage
     {
         public static string FieldIsRequired = "'{0}' is a required property of '{1}'.";
         public static string FieldIsNotValid = "'{0}' is not valid.";

--- a/src/lib/Extensions.cs
+++ b/src/lib/Extensions.cs
@@ -5,6 +5,8 @@ namespace Microsoft.OpenApi.ApiManifest;
 
 public class Extensions : Dictionary<string, JsonNode?>
 {
+    public Extensions() : base(StringComparer.OrdinalIgnoreCase) { }
+
     public static Extensions Load(JsonElement value)
     {
         var extensions = new Extensions();

--- a/src/lib/OpenAI/Api.cs
+++ b/src/lib/OpenAI/Api.cs
@@ -3,7 +3,8 @@ using System.Text.Json;
 
 namespace Microsoft.OpenApi.ApiManifest.OpenAI;
 
-public class Api {
+public class Api
+{
     public string? Type { get; set; }
     public string? Url { get; set; }
     public bool? IsUserAuthenticated { get; set; }
@@ -16,7 +17,7 @@ public class Api {
     }
 
     // Create handlers FixedFieldMap for Api
-    private static FixedFieldMap<Api> handlers = new()
+    private static readonly FixedFieldMap<Api> handlers = new()
     {
         { "type", (o,v) => {o.Type = v.GetString();  } },
         { "url", (o,v) => {o.Url = v.GetString();  } },

--- a/src/lib/OpenAI/OpenAIPluginManifest.cs
+++ b/src/lib/OpenAI/OpenAIPluginManifest.cs
@@ -29,7 +29,7 @@ public class OpenAIPluginManifest
     }
 
     // Create handlers FixedFieldMap for OpenAIPluginManifest
-    private static FixedFieldMap<OpenAIPluginManifest> handlers = new()
+    private static readonly FixedFieldMap<OpenAIPluginManifest> handlers = new()
     {
         { "schema_version", (o,v) => {o.SchemaVersion = v.GetString();  } },
         { "name_for_human", (o,v) => {o.NameForHuman = v.GetString();  } },
@@ -52,15 +52,17 @@ public class OpenAIPluginManifest
         writer.WriteString("name_for_model", NameForModel);
         writer.WriteString("description_for_human", DescriptionForHuman);
         writer.WriteString("description_for_model", DescriptionForModel);
-        if (Auth != null) {
+        if (Auth != null)
+        {
             writer.WritePropertyName("auth");
             Auth.Write(writer);
         }
-        if (Api != null) {
+        if (Api != null)
+        {
             writer.WritePropertyName("api");
             Api?.Write(writer);
         }
-        if (LogoUrl != null)writer.WriteString("logo_url", LogoUrl);
+        if (LogoUrl != null) writer.WriteString("logo_url", LogoUrl);
         if (ContactEmail != null) writer.WriteString("contact_email", ContactEmail);
         if (LegalInfoUrl != null) writer.WriteString("legal_info_url", LegalInfoUrl);
         writer.WriteEndObject();

--- a/src/lib/OpenAI/OpenApiPluginFactory.cs
+++ b/src/lib/OpenAI/OpenApiPluginFactory.cs
@@ -1,11 +1,15 @@
 
 namespace Microsoft.OpenApi.ApiManifest.OpenAI;
 
-public class OpenApiPluginFactory {
+public class OpenApiPluginFactory
+{
 
-    public static OpenAIPluginManifest CreateOpenAIPluginManifest() {
-        var manifest = new OpenAIPluginManifest();
-        manifest.SchemaVersion = "v1";
+    public static OpenAIPluginManifest CreateOpenAIPluginManifest()
+    {
+        var manifest = new OpenAIPluginManifest
+        {
+            SchemaVersion = "v1"
+        };
         return manifest;
     }
 }

--- a/src/lib/ParsingHelpers.cs
+++ b/src/lib/ParsingHelpers.cs
@@ -65,7 +65,7 @@ internal class ParsingHelpers
         {
             var value = item.GetString();
             if (value != null)
-                hashSet.Add(value);
+                _ = hashSet.Add(value);
         }
         return hashSet;
     }
@@ -77,7 +77,7 @@ internal class ParsingHelpers
         {
             var value = item.GetString();
             if (value != null)
-                sortedSet.Add(value);
+                _ = sortedSet.Add(value);
         }
         return sortedSet;
     }

--- a/src/lib/Publisher.cs
+++ b/src/lib/Publisher.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.OpenApi.ApiManifest;
 
@@ -6,36 +7,54 @@ public class Publisher
 {
     public string? Name { get; set; }
     public string? ContactEmail { get; set; }
+
     private const string NameProperty = "name";
     private const string ContactEmailProperty = "contactEmail";
 
-    public Publisher(string contactEmail)
+    private static readonly Regex s_emailRegex = new(@"^[^@\s]+@[^@\s]+\.[^@\s]+$", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
+
+    public Publisher(string name, string contactEmail)
     {
-        if (string.IsNullOrWhiteSpace(contactEmail)) throw new ArgumentNullException("Contact email is a required property of Publisher.");
+        Validate(name, contactEmail);
+
+        Name = name;
         ContactEmail = contactEmail;
     }
     private Publisher(JsonElement value)
     {
         ParsingHelpers.ParseMap(value, this, handlers);
-        // Validate that Name and ContactEmail are not null
-        if (string.IsNullOrWhiteSpace(Name)) throw new ArgumentNullException("Name is a required property of publisher.");
-        if (string.IsNullOrWhiteSpace(ContactEmail)) throw new ArgumentNullException("Contact email is a required property of Publisher.");
+        Validate(Name, ContactEmail);
     }
 
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
+        Validate(Name, ContactEmail);
+
         writer.WriteStartObject();
 
-        if (!string.IsNullOrWhiteSpace(Name)) writer.WriteString(NameProperty, Name);
-        if (!string.IsNullOrWhiteSpace(ContactEmail)) writer.WriteString(ContactEmailProperty, ContactEmail);
+        writer.WriteString(NameProperty, Name);
+        writer.WriteString(ContactEmailProperty, ContactEmail);
 
         writer.WriteEndObject();
     }
+
     // Load method
     internal static Publisher Load(JsonElement value)
     {
         return new Publisher(value);
+    }
+
+    private static void Validate(string? name, string? contactEmail)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentNullException(name, String.Format(ErrorConstants.FieldIsRequired, "name", "publisher"));
+
+        if (string.IsNullOrWhiteSpace(contactEmail))
+            throw new ArgumentNullException(contactEmail, String.Format(ErrorConstants.FieldIsRequired, "contactEmail", "publisher"));
+
+        if (!s_emailRegex.IsMatch(contactEmail))
+            throw new ArgumentException(string.Format(ErrorConstants.FieldIsNotValid, "contactEmail"), contactEmail);
     }
 
     private static readonly FixedFieldMap<Publisher> handlers = new()

--- a/src/lib/Publisher.cs
+++ b/src/lib/Publisher.cs
@@ -48,13 +48,13 @@ public class Publisher
     private static void Validate(string? name, string? contactEmail)
     {
         if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentNullException(name, String.Format(ErrorConstants.FieldIsRequired, "name", "publisher"));
+            throw new ArgumentNullException(name, String.Format(ErrorMessage.FieldIsRequired, "name", "publisher"));
 
         if (string.IsNullOrWhiteSpace(contactEmail))
-            throw new ArgumentNullException(contactEmail, String.Format(ErrorConstants.FieldIsRequired, "contactEmail", "publisher"));
+            throw new ArgumentNullException(contactEmail, String.Format(ErrorMessage.FieldIsRequired, "contactEmail", "publisher"));
 
         if (!s_emailRegex.IsMatch(contactEmail))
-            throw new ArgumentException(string.Format(ErrorConstants.FieldIsNotValid, "contactEmail"), contactEmail);
+            throw new ArgumentException(string.Format(ErrorMessage.FieldIsNotValid, "contactEmail"), contactEmail);
     }
 
     private static readonly FixedFieldMap<Publisher> handlers = new()

--- a/src/lib/Publisher.cs
+++ b/src/lib/Publisher.cs
@@ -11,7 +11,7 @@ public class Publisher
     private const string NameProperty = "name";
     private const string ContactEmailProperty = "contactEmail";
 
-    private static readonly Regex s_emailRegex = new(@"^[^@\s]+@[^@\s]+\.[^@\s]+$", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
+    private static readonly Regex s_emailRegex = new(@"^[^@\s]+@[^@\s]+$", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
 
     public Publisher(string name, string contactEmail)
     {

--- a/src/lib/Request.cs
+++ b/src/lib/Request.cs
@@ -26,7 +26,7 @@ public class Request
         writer.WriteEndObject();
     }
     // Fixed fieldmap for Request
-    private static FixedFieldMap<Request> handlers = new()
+    private static readonly FixedFieldMap<Request> handlers = new()
     {
         { MethodProperty, (o,v) => {o.Method = v.GetString();  } },
         { UriTemplateProperty, (o,v) => {o.UriTemplate = v.GetString();  } },

--- a/src/tests/CreateTests.cs
+++ b/src/tests/CreateTests.cs
@@ -2,36 +2,39 @@ using System.Text.Json.Nodes;
 
 namespace Tests.ApiManifest;
 
-public class CreateTests {
+public class CreateTests
+{
 
     [Fact]
-    public void CreateEmptyApiManifestDocument() {
-        var apiManifest = new ApiManifestDocument();
+    public void CreateApiManifestDocumentWithRequiredFields()
+    {
+        var apiManifest = new ApiManifestDocument("application-name");
         Assert.NotNull(apiManifest);
+        Assert.Equal("application-name", apiManifest.ApplicationName);
+        Assert.Null(apiManifest.Publisher);
+        Assert.Empty(apiManifest.ApiDependencies);
+        Assert.Empty(apiManifest.Extensions);
     }
 
     [Fact]
-    public void CreatePublisher() {
-        var publisher = new Publisher(contactEmail: "foo@bar.com") {
-            Name = "Contoso"
-        };
+    public void CreatePublisher()
+    {
+        var publisher = new Publisher(name: "Contoso", contactEmail: "foo@bar.com");
         Assert.Equal("Contoso", publisher.Name);
         Assert.Equal("foo@bar.com", publisher.ContactEmail);
-        
+
     }
 
     // Create test to instantiate ApiManifest with auth
     [Fact]
-    public void CreateApiManifestWithAuth() {
-        var apiManifest = new ApiManifestDocument()
+    public void CreateApiManifestWithAuthorizationRequirements()
+    {
+        var apiManifest = new ApiManifestDocument("application-name")
         {
-            Publisher = new(contactEmail: "foo@bar.com")
-            {
-                Name = "Contoso"
-            },
+            Publisher = new(name: "Contoso", contactEmail: "foo@bar.com"),
             ApiDependencies = new() {
                 { "Contoso.Api", new() {
-                    Auth = new() {
+                    AuthorizationRequirements = new() {
                         ClientIdentifier = "2143234-234324-234234234-234",
                         Access = new() {
                             new() { Type = "oauth2",
@@ -41,13 +44,13 @@ public class CreateTests {
                                 }
                             }
                         }
-                    } 
+                    }
                 }
             }
         };
-        Assert.NotNull(apiManifest.ApiDependencies["Contoso.Api"].Auth);
-        Assert.Equal("2143234-234324-234234234-234", apiManifest?.ApiDependencies["Contoso.Api"]?.Auth?.ClientIdentifier);
-        Assert.Equal("oauth2", apiManifest?.ApiDependencies["Contoso.Api"]?.Auth?.Access[0].Type);
+        Assert.NotNull(apiManifest.ApiDependencies["Contoso.Api"].AuthorizationRequirements);
+        Assert.Equal("2143234-234324-234234234-234", apiManifest?.ApiDependencies["Contoso.Api"]?.AuthorizationRequirements?.ClientIdentifier);
+        Assert.Equal("oauth2", apiManifest?.ApiDependencies["Contoso.Api"]?.AuthorizationRequirements?.Access[0].Type);
     }
 
 }

--- a/src/tests/CreateTests.cs
+++ b/src/tests/CreateTests.cs
@@ -16,13 +16,29 @@ public class CreateTests
         Assert.Empty(apiManifest.Extensions);
     }
 
-    [Fact]
-    public void CreatePublisher()
+    [Theory]
+    [InlineData("foo@bar")]
+    [InlineData("foo@bar.com")]
+    public void CreatePublisher(string contactEmail)
     {
-        var publisher = new Publisher(name: "Contoso", contactEmail: "foo@bar.com");
+        var publisher = new Publisher(name: "Contoso", contactEmail: contactEmail);
         Assert.Equal("Contoso", publisher.Name);
-        Assert.Equal("foo@bar.com", publisher.ContactEmail);
+        Assert.Equal(contactEmail, publisher.ContactEmail);
 
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData("foo@")]
+    [InlineData("foo@@bar.com")]
+    [InlineData("foo @bar.com")]
+    public void CreatePublisherWithInvalidEmail(string contactEmail)
+    {
+        _ = Assert.Throws<ArgumentException>(() =>
+        {
+            var publisher = new Publisher(name: "Contoso", contactEmail: contactEmail);
+        }
+        );
     }
 
     // Create test to instantiate ApiManifest with auth

--- a/src/tests/PluginTests.cs
+++ b/src/tests/PluginTests.cs
@@ -1,7 +1,7 @@
 // Write tests for OpenAIPluginManifest
 
-using System.Text.Json;
 using Microsoft.OpenApi.ApiManifest.OpenAI;
+using System.Text.Json;
 
 namespace Tests.OpenAI
 {
@@ -41,7 +41,7 @@ namespace Tests.OpenAI
             Assert.Equal("https://avatars.githubusercontent.com/foo", manifest.LogoUrl);
             Assert.Equal("joe@demo.com", manifest.ContactEmail);
         }
- 
+
         // Create minimal OpenAIPluginManifest
         [Fact]
         public void WriteOpenAIPluginManifest()
@@ -89,8 +89,8 @@ namespace Tests.OpenAI
     },
     ""logo_url"": ""https://avatars.githubusercontent.com/bar"",
     ""contact_email"": ""joe@test.com""
-}", json, ignoreLineEndingDifferences: true,ignoreWhiteSpaceDifferences: true);
-        }   
+}", json, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
 
         [Fact]
         public void WriteOAuthTest()
@@ -104,7 +104,7 @@ namespace Tests.OpenAI
                 DescriptionForModel = "SomeModelDescription",
                 Auth = new ManifestOAuthAuth
                 {
-                    AuthorizationUrl = "https://api.openai.com/oauth/authorize", 
+                    AuthorizationUrl = "https://api.openai.com/oauth/authorize",
                 },
                 Api = new Api
                 {
@@ -142,10 +142,10 @@ namespace Tests.OpenAI
     },
     ""logo_url"": ""https://avatars.githubusercontent.com/bar"",
     ""contact_email"": ""joe@test.com""
-}", json, ignoreLineEndingDifferences: true,ignoreWhiteSpaceDifferences: true);
-        }   
+}", json, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
 
     }
 
-    
+
 }

--- a/src/tests/Usings.cs
+++ b/src/tests/Usings.cs
@@ -1,2 +1,2 @@
-global using Xunit;
 global using Microsoft.OpenApi.ApiManifest;
+global using Xunit;


### PR DESCRIPTION
This PR fixes #5 by providing an initial draft to add validation per the API manifest spec. The PR proposes the following changes:
- Adds missing `applicationName` property to `apiManifest`.
- Adds required validation for:
  - `apiManifest.applicationName`
  - `publisher.name`
  - `publisher.contactEmail`
- Adds email validation for `publisher.contactEmail`.
- Renames `apiDependency.auth` property to `apiDependency.authorizationRequirements` per API manifest spec.

### Open Questions
##### Spec (see #5 for more details)
- [x] Should [section 2.4](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html#section-2.4) of the spec be updated to use `clientIdentifier` instead of `clientId`? Should we add requirement levels for authorization requirements object properties?
- [x] `apiDependency.apiDeploymentBaseUrl` should be added to [section 2.3](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html#section-2.3).
- We should explicitly specify requirement levels for properties of the following objects:
  - [x] All `requestInfo` properties. The example in the spec suggests that `method` and `uriTemplate` are required yet section [2.5. Request Info Object](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html#section-2.5) makes no mention of their requirement level.
  - [x] `apiDependency.authorizationRequirements` and `apiDependency.requests` properties when initializing an `apiDependency` object. [Section 2.3](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html#section-2.3) makes no mention of their requirement level.
##### .NET Lib Implementation
- [x] Is [`authorizationRequirements.accessReference`](https://github.com/microsoft/OpenApi.ApiManifest/blob/96b16a2c710e44765d12ae39c50b2b7b2410e4e0/src/lib/Auth.cs#L8) needed? The property is not described in the spec.
- [x] Should we rename [`accessRequest.content`](https://github.com/microsoft/OpenApi.ApiManifest/blob/96b16a2c710e44765d12ae39c50b2b7b2410e4e0/src/lib/AccessRequest.cs#L13) to `accessRequest.actions` to match RAR's `authorization_details`?
- Should .NET lib's type name match the spec's type names? This is needed to aid in discoverability when using the .NET lib. If so, then the following types will need to be renamed:
  - [x] Rename [`Request` class](https://github.com/microsoft/OpenApi.ApiManifest/blob/main/src/lib/Request.cs) to `RequestInfo`.
  - [ ] Rename [`Extensions` class](https://github.com/microsoft/OpenApi.ApiManifest/blob/main/src/lib/Extensions.cs) to `Extensibility`. We need to settle on an appropriate property and type name. Extensibility vs extensions?
- [x] Should we only support `type` and `actions` from RAR's `authorization_details`? `type` is the only required field. Common data fields are optional according to [RAR](https://www.rfc-editor.org/rfc/rfc9396#section-2.2):
  > This specification does not require the use of these common fields by an API definition but, instead, provides them as reusable generic components for API designers to make use of. The allowable values of all fields are determined by the API being protected, as defined by a particular "type" value.

### Reference links
- [API manifest spec](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html).
- [Rich Authorization Requests (RAR) spec](https://www.rfc-editor.org/rfc/rfc9396).