### PR TITLE
Adds support for conversion of API manifest document to OpenAI Plugin manifest

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -84,7 +84,7 @@ stages:
         displayName: 'Run CredScan - Test'
         inputs:
           toolMajorVersion: 'V2'
-          scanFolder: '$(Build.SourcesDirectory)\src\tests'
+          scanFolder: '$(Build.SourcesDirectory)\tests'
           debugMode: false
 
       - task: AntiMalware@3

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @peombwa @darrelmiller @baywet
+* @peombwa @darrelmiller @baywet @zengin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Added support for conversion of API manifest document to OpenAI Plugin manifest. #4
+- Added VerificationTokens property to OpenAI Plugin manifest auth type. #32
+- Added OpenAI Plugin manifest validation. #32
+- Added API Manifest validation. #5
+- Added ApplicationName property to ApiManifestDocument. #5
+
+### Changed
+
+- Renamed Request class to RequestInfo to align with the API manifest specification. #21
+- Renamed Auth property in ApiDependency to AuthorizationRequirements to align with the API manifest specification. #5
+
+## [0.5.1] - 2023-08-17
+
+### Changed
+
+- Fixed typos in properties.
+
+## [0.5.0] - 2023-08-17
+
+### Added
+
+- Initial release of the library.

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -17,33 +17,27 @@ public class ApiManifestDocument
 
     public ApiManifestDocument(string applicationName)
     {
-        Validate(applicationName);
-
         ApplicationName = applicationName;
+        Validate();
     }
 
     public ApiManifestDocument(JsonElement value)
     {
         ParsingHelpers.ParseMap(value, this, handlers);
-
-        Validate(ApplicationName);
+        Validate();
     }
 
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        Validate(ApplicationName);
-
+        Validate();
         writer.WriteStartObject();
-
         writer.WriteString(ApplicationNameProperty, ApplicationName);
-
         if (Publisher != null)
         {
             writer.WritePropertyName(PublisherProperty);
             Publisher.Write(writer);
         }
-
         if (ApiDependencies.Any())
         {
             writer.WritePropertyName(ApiDependenciesProperty);
@@ -55,13 +49,11 @@ public class ApiManifestDocument
             }
             writer.WriteEndObject();
         }
-
         if (Extensions.Any())
         {
             writer.WritePropertyName(ExtensionsProperty);
             Extensions.Write(writer);
         }
-
         writer.WriteEndObject();
     }
 
@@ -71,9 +63,10 @@ public class ApiManifestDocument
         return new ApiManifestDocument(value);
     }
 
-    private static void Validate(string? applicationName)
+    internal void Validate()
     {
-        ValidationHelpers.ValidateNullOrWhitespace(nameof(applicationName), applicationName, nameof(ApiManifestDocument));
+        ValidationHelpers.ValidateNullOrWhitespace(nameof(ApplicationName), ApplicationName, nameof(ApiManifestDocument));
+        Publisher?.Validate();
     }
 
     // Create fixed field map for ApiManifest

--- a/src/lib/Constants.cs
+++ b/src/lib/Constants.cs
@@ -14,5 +14,7 @@ namespace Microsoft.OpenApi.ApiManifest
         public static readonly string FieldIsNotValid = "'{0}' is not valid.";
         public static readonly string FieldLengthExceeded = "'{0}' length exceeded. Maximum length allowed is '{1}'.";
         public static readonly string BaseUrlIsNotValid = "The {0} must be a valid URL and end in a slash.";
+        public static readonly string ApiDependencyNotFound = "Failed to get a valid apiDependency from the provided apiManifestDocument. The property is required generate a complete {0}.";
+        public static readonly string ApiDescriptionUrlNotFound = "ApiDescriptionUrl is missing in the provided apiManifestDocument. The property is required generate a complete {0}.";
     }
 }

--- a/src/lib/Exceptions/ApiManifestException.cs
+++ b/src/lib/Exceptions/ApiManifestException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.OpenApi.ApiManifest.Exceptions
+{
+    public class ApiManifestException : Exception
+    {
+        public ApiManifestException(string message) : base(message)
+        {
+        }
+
+        public ApiManifestException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/lib/Helpers/ParsingHelpers.cs
+++ b/src/lib/Helpers/ParsingHelpers.cs
@@ -10,18 +10,13 @@ namespace Microsoft.OpenApi.ApiManifest.Helpers;
 
 internal static class ParsingHelpers
 {
-    private static readonly Lazy<HttpClient> s_httpClient;
-
-    static ParsingHelpers()
+    private static readonly Lazy<HttpClient> s_httpClient = new(() => new HttpClient(new HttpClientHandler()
     {
-        s_httpClient = new(() => new HttpClient(new HttpClientHandler()
-        {
-            SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-        }))
-        {
-            Value = { DefaultRequestVersion = HttpVersion.Version20 }
-        };
-    }
+        SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+    }))
+    {
+        Value = { DefaultRequestVersion = HttpVersion.Version20 }
+    };
 
     internal static void ParseMap<T>(JsonElement node, T permissionsDocument, FixedFieldMap<T> handlers)
     {

--- a/src/lib/Helpers/ParsingHelpers.cs
+++ b/src/lib/Helpers/ParsingHelpers.cs
@@ -150,7 +150,7 @@ internal static class ParsingHelpers
     internal static async Task<ReadResult> ParseOpenApiAsync(Uri openApiFileUri, bool inlineExternal, CancellationToken cancellationToken)
     {
         await using var stream = await GetStreamAsync(openApiFileUri, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return await ParseOpenApiAsync(stream, openApiFileUri, inlineExternal, cancellationToken);
+        return await ParseOpenApiAsync(stream, openApiFileUri, inlineExternal, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<ReadResult> ParseOpenApiAsync(Stream stream, Uri openApiFileUri, bool inlineExternal, CancellationToken cancellationToken)

--- a/src/lib/Publisher.cs
+++ b/src/lib/Publisher.cs
@@ -13,22 +13,20 @@ public class Publisher
 
     public Publisher(string name, string contactEmail)
     {
-        Validate(name, contactEmail);
-
         Name = name;
         ContactEmail = contactEmail;
+        Validate();
     }
     private Publisher(JsonElement value)
     {
         ParsingHelpers.ParseMap(value, this, handlers);
-        Validate(Name, ContactEmail);
+        Validate();
     }
 
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        Validate(Name, ContactEmail);
-
+        Validate();
         writer.WriteStartObject();
         writer.WriteString(NameProperty, Name);
         writer.WriteString(ContactEmailProperty, ContactEmail);
@@ -41,10 +39,10 @@ public class Publisher
         return new Publisher(value);
     }
 
-    private static void Validate(string? name, string? contactEmail)
+    internal void Validate()
     {
-        ValidationHelpers.ValidateNullOrWhitespace(nameof(name), name, nameof(Publisher));
-        ValidationHelpers.ValidateEmail(nameof(contactEmail), contactEmail, nameof(Publisher));
+        ValidationHelpers.ValidateNullOrWhitespace(nameof(Name), Name, nameof(Publisher));
+        ValidationHelpers.ValidateEmail(nameof(ContactEmail), ContactEmail, nameof(Publisher));
     }
 
     private static readonly FixedFieldMap<Publisher> handlers = new()

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -9,16 +9,16 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
     public static class ApiManifestDocumentExtensions
     {
         /// <summary>
-        /// Generates an OpenAIPluginManifest from the provided ApiManifestDocument.
+        /// Converts an instance of <see cref="ApiManifestDocument"/> to an instance of <see cref="OpenAIPluginManifest"/>.
         /// </summary>
         /// <param name="apiManifestDocument">A valid instance of <see cref="ApiManifestDocument"/> to generate an OpenAI Plugin manifest from.</param>
-        /// <param name="logoUrl"> The URL to a logo for the plugin.</param>
+        /// <param name="logoUrl">The URL to a logo for the plugin.</param>
         /// <param name="legalInfoUrl">The URL to a page with legal information about the plugin.</param>
         /// <param name="apiDependencyName">The name of apiDependency to use from the provided <see cref="ApiManifestDocument.ApiDependencies"/>. The method defaults to the first apiDependency in  <see cref="ApiManifestDocument.ApiDependencies"/> if no value is provided.</param>
-        /// <param name="openApiFilePath">The relative path to where the OpenAPI file that's packaged with the plugin manifest if stored. The method default './openapi.json' if none is provided.</param>
+        /// <param name="openApiPath">The path to where the OpenAPI file that's packaged with the plugin manifest is stored. The method defaults to the ApiDependency.ApiDescriptionUrl if none is provided.</param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         /// <returns>A <see cref="Task{OpenAIPluginManifest}"/></returns>
-        public static async Task<OpenAIPluginManifest> ToOpenAIPluginManifestAsync(this ApiManifestDocument apiManifestDocument, string logoUrl, string legalInfoUrl, string? apiDependencyName = default, string openApiFilePath = "./openapi.json", CancellationToken cancellationToken = default)
+        public static async Task<OpenAIPluginManifest> ToOpenAIPluginManifestAsync(this ApiManifestDocument apiManifestDocument, string logoUrl, string legalInfoUrl, string? apiDependencyName = default, string? openApiPath = default, CancellationToken cancellationToken = default)
         {
             if (!TryGetApiDependency(apiManifestDocument.ApiDependencies, apiDependencyName, out ApiDependency? apiDependency))
             {
@@ -30,26 +30,28 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             }
             else
             {
-                var result = await ParsingHelpers.ParseOpenApiAsync(apiDependency.ApiDescriptionUrl, false, cancellationToken);
-                return apiManifestDocument.ToOpenAIPluginManifest(openApiDocument: result.OpenApiDocument, logoUrl: logoUrl, legalInfoUrl: legalInfoUrl, openApiFilePath: openApiFilePath);
+                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency.ApiDescriptionUrl), false, cancellationToken);
+                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath ?? apiDependency.ApiDescriptionUrl);
             }
         }
 
-        internal static OpenAIPluginManifest ToOpenAIPluginManifest(this ApiManifestDocument apiManifestDocument, OpenApiDocument openApiDocument, string logoUrl, string legalInfoUrl, string openApiFilePath)
+        /// <summary>
+        /// Converts an instance of <see cref="ApiManifestDocument"/> to an instance of <see cref="OpenAIPluginManifest"/>.
+        /// </summary>
+        /// <param name="apiManifestDocument">A valid instance of <see cref="ApiManifestDocument"/> with at least one API dependency.</param>
+        /// <param name="openApiDocument">The OpenAPI document to use for the OpenAIPluginManifest.</param>
+        /// <param name="logoUrl">The URL to a logo for the plugin.</param>
+        /// <param name="legalInfoUrl">The URL to a page with legal information about the plugin.</param>
+        /// <param name="openApiPath">The path to where the OpenAPI file that's packaged with the plugin manifest is stored.</param>
+        /// <returns>A <see cref="OpenAIPluginManifest"/></returns>
+        public static OpenAIPluginManifest ToOpenAIPluginManifest(this ApiManifestDocument apiManifestDocument, OpenApiDocument openApiDocument, string logoUrl, string legalInfoUrl, string openApiPath)
         {
-            // Validate the ApiManifestDocument before generating the OpenAI manifest.
+            // Validates the ApiManifestDocument before generating the OpenAI manifest. This includes the publisher object.
             apiManifestDocument.Validate();
-            string contactEmail = string.IsNullOrWhiteSpace(apiManifestDocument.Publisher?.ContactEmail) ? string.Empty : apiManifestDocument.Publisher.ContactEmail;
+            string contactEmail = apiManifestDocument.Publisher?.ContactEmail!;
 
-            var openApiManifest = OpenApiPluginFactory.CreateOpenAIPluginManifest(
-                schemaVersion: openApiDocument.Info.Version,
-                nameForHuman: openApiDocument.Info.Title,
-                nameForModel: openApiDocument.Info.Title,
-                logoUrl: logoUrl,
-                contactEmail: contactEmail,
-                legalInfoUrl: legalInfoUrl);
-
-            openApiManifest.Api = new Api("openapi", openApiFilePath);
+            var openApiManifest = OpenApiPluginFactory.CreateOpenAIPluginManifest(openApiDocument.Info.Title, openApiDocument.Info.Title, logoUrl, contactEmail, legalInfoUrl, openApiDocument.Info.Version);
+            openApiManifest.Api = new Api("openapi", openApiPath);
             openApiManifest.Auth = new ManifestNoAuth();
             openApiManifest.DescriptionForHuman = openApiDocument.Info.Description ?? $"Description for {openApiManifest.NameForHuman}.";
             openApiManifest.DescriptionForModel = openApiManifest.DescriptionForHuman;

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
         /// <returns>Returns true if the apiDependency is found and not null, otherwise false.</returns>
         private static bool TryGetApiDependency(ApiDependencies apiDependencies, string? apiDependencyName, out ApiDependency? apiDependency)
         {
-            if (apiDependencyName == default)
+            if (string.IsNullOrEmpty(apiDependencyName))
                 apiDependency = apiDependencies.FirstOrDefault().Value;
             else
                 _ = apiDependencies.TryGetValue(apiDependencyName, out apiDependency);

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             }
             else
             {
-                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency.ApiDescriptionUrl), false, cancellationToken);
+                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
                 return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath ?? apiDependency.ApiDescriptionUrl);
             }
         }
@@ -59,6 +59,13 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             return openApiManifest;
         }
 
+        /// <summary>
+        /// Tries to get an <see cref="ApiDependency"/> from the provided <see cref="ApiDependencies"/>.
+        /// </summary>
+        /// <param name="apiDependencies">The <see cref="ApiDependencies"/> to search for the apiDependency.</param>
+        /// <param name="apiDependencyName">The name of apiDependency to use from the provided <see cref="ApiManifestDocument.ApiDependencies"/>. The method defaults to the first apiDependency in <see cref="ApiManifestDocument.ApiDependencies"/> if no value is provided.</param>
+        /// <param name="apiDependency">The <see cref="ApiDependency"/> that was found.</param>
+        /// <returns>Returns true if the apiDependency is found and not null, otherwise false.</returns>
         private static bool TryGetApiDependency(ApiDependencies apiDependencies, string? apiDependencyName, out ApiDependency? apiDependency)
         {
             if (apiDependencyName == default)

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.ApiManifest.Helpers;
+﻿using Microsoft.OpenApi.ApiManifest.Exceptions;
+using Microsoft.OpenApi.ApiManifest.Helpers;
 using Microsoft.OpenApi.ApiManifest.OpenAI;
 using Microsoft.OpenApi.ApiManifest.OpenAI.Authentication;
 using Microsoft.OpenApi.Models;
@@ -21,18 +22,16 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
         {
             if (!TryGetApiDependency(apiManifestDocument.ApiDependencies, apiDependencyName, out ApiDependency? apiDependency))
             {
-                throw new ArgumentException("Failed to get a valid apiDependency from the provided apiManifestDocument", nameof(apiManifestDocument.ApiDependencies));
+                throw new ApiManifestException(string.Format(ErrorMessage.ApiDependencyNotFound, nameof(OpenAIPluginManifest)));
             }
             else if (string.IsNullOrWhiteSpace(apiDependency?.ApiDescriptionUrl))
             {
-                throw new ArgumentNullException(nameof(apiDependency.ApiDescriptionUrl), "ApiDescriptionUrl is missing in the provided apiManifestDocument. The property is required generate a complete OpenAI Plugin manifest.");
+                throw new ApiManifestException(string.Format(ErrorMessage.ApiDescriptionUrlNotFound, nameof(OpenAIPluginManifest)));
             }
             else
             {
                 var result = await ParsingHelpers.ParseOpenApiAsync(apiDependency.ApiDescriptionUrl, false, cancellationToken);
-                OpenApiDocument document = result.OpenApiDocument;
-
-                return apiManifestDocument.ToOpenAIPluginManifest(openApiDocument: document, logoUrl: logoUrl, legalInfoUrl: legalInfoUrl, openApiFilePath: openApiFilePath);
+                return apiManifestDocument.ToOpenAIPluginManifest(openApiDocument: result.OpenApiDocument, logoUrl: logoUrl, legalInfoUrl: legalInfoUrl, openApiFilePath: openApiFilePath);
             }
         }
 

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.OpenApi.ApiManifest.Helpers;
+using Microsoft.OpenApi.ApiManifest.OpenAI;
+using Microsoft.OpenApi.ApiManifest.OpenAI.Authentication;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
+{
+    public static class ApiManifestDocumentExtensions
+    {
+        /// <summary>
+        /// Generates an OpenAIPluginManifest from the provided ApiManifestDocument.
+        /// </summary>
+        /// <param name="apiManifestDocument">A valid instance of <see cref="ApiManifestDocument"/> to generate an OpenAI Plugin manifest from.</param>
+        /// <param name="logoUrl"> The URL to a logo for the plugin.</param>
+        /// <param name="legalInfoUrl">The URL to a page with legal information about the plugin.</param>
+        /// <param name="apiDependencyName">The name of apiDependency to use from the provided <see cref="ApiManifestDocument.ApiDependencies"/>. The method defaults to the first apiDependency in  <see cref="ApiManifestDocument.ApiDependencies"/> if no value is provided.</param>
+        /// <param name="openApiFilePath">The relative path to where the OpenAPI file that's packaged with the plugin manifest if stored. The method default './openapi.json' if none is provided.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public static async Task<OpenAIPluginManifest> ToOpenAIPluginManifestAsync(this ApiManifestDocument apiManifestDocument, string logoUrl, string legalInfoUrl, string? apiDependencyName = default, string openApiFilePath = "./openapi.json", CancellationToken cancellationToken = default)
+        {
+            if (!TryGetApiDependency(apiManifestDocument, apiDependencyName, out ApiDependency? apiDependency))
+            {
+                throw new Exception("Failed to get a valid apiDependency from the provided apiManifestDocument");
+            }
+            else if (string.IsNullOrWhiteSpace(apiDependency?.ApiDescriptionUrl))
+            {
+                throw new ArgumentException("ApiDescriptionUrl is missing in the provided apiManifestDocument. The property is required generate a complete OpenAI Plugin manifest.");
+            }
+            else
+            {
+                var result = await ParsingHelpers.ParseOpenApiAsync(apiDependency.ApiDescriptionUrl, false, cancellationToken);
+                OpenApiDocument document = result.OpenApiDocument;
+
+                return apiManifestDocument.ToOpenAIPluginManifest(openApiDocument: document, logoUrl: logoUrl, legalInfoUrl: legalInfoUrl, openApiFilePath: openApiFilePath);
+            }
+        }
+
+        internal static OpenAIPluginManifest ToOpenAIPluginManifest(this ApiManifestDocument apiManifestDocument, OpenApiDocument openApiDocument, string logoUrl, string legalInfoUrl, string openApiFilePath)
+        {
+            // apiManifestDocument.Validate(); // TODO: Validate the ApiManifestDocument before generating the OpenAI manifest.
+            string contactEmail = string.IsNullOrWhiteSpace(apiManifestDocument.Publisher?.ContactEmail) ? string.Empty : apiManifestDocument.Publisher.ContactEmail;
+
+            var openApiManifest = OpenApiPluginFactory.CreateOpenAIPluginManifest(
+                schemaVersion: openApiDocument.Info.Version,
+                nameForHuman: openApiDocument.Info.Title,
+                nameForModel: openApiDocument.Info.Title,
+                logoUrl: logoUrl,
+                contactEmail: contactEmail,
+                legalInfoUrl: legalInfoUrl);
+
+            openApiManifest.Api = new Api("openapi", openApiFilePath);
+            openApiManifest.Auth = new ManifestNoAuth();
+            openApiManifest.DescriptionForHuman = openApiDocument.Info.Description ?? $"Description for {openApiManifest.NameForHuman}.";
+            openApiManifest.DescriptionForModel = openApiManifest.DescriptionForHuman;
+
+            return openApiManifest;
+        }
+
+        private static bool TryGetApiDependency(ApiManifestDocument apiManifestDocument, string? apiDependencyName, out ApiDependency? apiDependency)
+        {
+            if (apiDependencyName == default)
+                apiDependency = apiManifestDocument.ApiDependencies.FirstOrDefault().Value;
+            else
+                _ = apiManifestDocument.ApiDependencies.TryGetValue(apiDependencyName, out apiDependency);
+            return apiDependency != null;
+        }
+    }
+}

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -22,4 +22,8 @@
     <AssemblyOriginatorKeyFile>..\sgKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.9" />
+  </ItemGroup>
+
 </Project>

--- a/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
+++ b/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.5.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -35,6 +36,9 @@
 
   <ItemGroup>
     <None Update="TestFiles\exampleApiManifest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFiles\testOpenApi.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
+++ b/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
@@ -18,7 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
+++ b/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
@@ -33,4 +33,10 @@
     <ProjectReference Include="..\..\src\lib\apimanifest.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TestFiles\exampleApiManifest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
+++ b/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
@@ -112,5 +112,14 @@ namespace Microsoft.OpenApi.ApiManifest.Tests.Helpers
             var kvPairs = ParsingHelpers.ParseKey(exampleKeyValuePair);
             Assert.Equal(3, kvPairs.Count());
         }
+
+        [Fact]
+        public async Task ParseOpenApiAsync()
+        {
+            var openApiUrl = "https://raw.githubusercontent.com/APIPatterns/Moostodon/main/spec/tsp-output/%40typespec/openapi3/openapi.yaml";
+            var results = await ParsingHelpers.ParseOpenApiAsync(openApiUrl, false, CancellationToken.None);
+            Assert.Empty(results.OpenApiDiagnostic.Errors);
+            Assert.NotNull(results.OpenApiDocument);
+        }
     }
 }

--- a/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
+++ b/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
@@ -121,5 +121,19 @@ namespace Microsoft.OpenApi.ApiManifest.Tests.Helpers
             Assert.Empty(results.OpenApiDiagnostic.Errors);
             Assert.NotNull(results.OpenApiDocument);
         }
+
+        [Fact]
+        public void ParseOpenApiWithWrongOpenApiUrl()
+        {
+            var openApiUrl = "https://contoso.com/APIPatterns/Contoso/main/spec/tsp-output/%40typespec/openapi3/openapi.yaml";
+            _ = Assert.ThrowsAsync<InvalidOperationException>(async () => await ParsingHelpers.ParseOpenApiAsync(openApiUrl, false, CancellationToken.None));
+        }
+
+        [Fact]
+        public void ParseOpenApiWithOpenApiUrlWithAnInvalidSchema()
+        {
+            var openApiUrl = "contoso.com/APIPatterns/Contoso/main/spec/tsp-output/%40typespec/openapi3/openapi.yaml";
+            _ = Assert.ThrowsAsync<ArgumentException>(async () => await ParsingHelpers.ParseOpenApiAsync(openApiUrl, false, CancellationToken.None));
+        }
     }
 }

--- a/tests/ApiManifest.Tests/OpenAIPluginManifestTests.cs
+++ b/tests/ApiManifest.Tests/OpenAIPluginManifestTests.cs
@@ -499,7 +499,7 @@ public class OpenAIPluginManifestTests
     [Fact]
     public async Task GenerateOpenAIPluginManifestFromApiManifestAsync()
     {
-        var openAiPluginManifest = await exampleApiManifest.ToOpenAIPluginManifestAsync(logoUrl: "https://avatars.githubusercontent.com/bar", legalInfoUrl: "https://legalinfo.foobar.com");
+        var openAiPluginManifest = await exampleApiManifest.ToOpenAIPluginManifestAsync("https://avatars.githubusercontent.com/bar", "https://legalinfo.foobar.com");
 
         Assert.Equal("1.0.0", openAiPluginManifest.SchemaVersion);
         Assert.Equal("Mastodon", openAiPluginManifest.NameForHuman);
@@ -508,7 +508,7 @@ public class OpenAIPluginManifestTests
         Assert.Equal("Description for Mastodon.", openAiPluginManifest.DescriptionForModel);
         _ = Assert.IsType<ManifestNoAuth>(openAiPluginManifest.Auth);
         Assert.Equal("openapi", openAiPluginManifest.Api?.Type);
-        Assert.Equal("./openapi.json", openAiPluginManifest.Api?.Url);
+        Assert.Equal(exampleApiManifest.ApiDependencies.FirstOrDefault().Value.ApiDescriptionUrl, openAiPluginManifest.Api?.Url);
         Assert.Equal("https://avatars.githubusercontent.com/bar", openAiPluginManifest.LogoUrl);
         Assert.Equal("https://legalinfo.foobar.com", openAiPluginManifest.LegalInfoUrl);
     }
@@ -516,11 +516,7 @@ public class OpenAIPluginManifestTests
     [Fact]
     public async Task GenerateOpenAIPluginManifestFromApiManifestOfAnApiDependencyAsync()
     {
-        var openAiPluginManifest = await exampleApiManifest.ToOpenAIPluginManifestAsync(
-            logoUrl: "https://avatars.githubusercontent.com/bar",
-            legalInfoUrl: "https://legalinfo.foobar.com",
-            apiDependencyName: "MicrosoftGraph",
-            openApiFilePath: "./openapi.yml");
+        var openAiPluginManifest = await exampleApiManifest.ToOpenAIPluginManifestAsync("https://avatars.githubusercontent.com/bar", "https://legalinfo.foobar.com", "MicrosoftGraph", "./openapi.yml");
 
         Assert.Equal("v1.0", openAiPluginManifest.SchemaVersion);
         Assert.Equal("DirectoryObjects", openAiPluginManifest.NameForHuman);
@@ -537,11 +533,8 @@ public class OpenAIPluginManifestTests
     [Fact]
     public void GenerateOpenAIPluginManifestFromApiManifestWithWrongApiDependency()
     {
-        _ = Assert.ThrowsAsync<ApiManifestException>(async () => await exampleApiManifest.ToOpenAIPluginManifestAsync(
-            logoUrl: "https://avatars.githubusercontent.com/bar",
-            legalInfoUrl: "https://legalinfo.foobar.com",
-            apiDependencyName: "ContosoApi",
-            openApiFilePath: "./openapi.yml"));
+        _ = Assert.ThrowsAsync<ApiManifestException>(
+            async () => await exampleApiManifest.ToOpenAIPluginManifestAsync("https://avatars.githubusercontent.com/bar", "https://legalinfo.foobar.com", "ContosoApi", "./openapi.yml"));
     }
 
     [Fact]
@@ -550,22 +543,13 @@ public class OpenAIPluginManifestTests
         var apiManifest = LoadTestApiManifestDocument();
         apiManifest.ApiDependencies.Clear();
 
-        _ = Assert.ThrowsAsync<ApiManifestException>(async () => await apiManifest.ToOpenAIPluginManifestAsync(
-            logoUrl: "https://avatars.githubusercontent.com/bar",
-            legalInfoUrl: "https://legalinfo.foobar.com",
-            apiDependencyName: "MicrosoftGraph",
-            openApiFilePath: "./openapi.yml"));
+        _ = Assert.ThrowsAsync<ApiManifestException>(
+            async () => await apiManifest.ToOpenAIPluginManifestAsync("https://avatars.githubusercontent.com/bar", "https://legalinfo.foobar.com", "MicrosoftGraph", "./openapi.yml"));
     }
 
     private static OpenAIPluginManifest CreateManifestPlugIn()
     {
-        var manifest = OpenApiPluginFactory.CreateOpenAIPluginManifest(
-            schemaVersion: "1.0.0",
-            nameForHuman: "TestOAuth",
-            nameForModel: "TestOAuthModel",
-            logoUrl: "https://avatars.githubusercontent.com/bar",
-            legalInfoUrl: "https://legalinfo.foobar.com",
-            contactEmail: "joe@test.com");
+        var manifest = OpenApiPluginFactory.CreateOpenAIPluginManifest("TestOAuthModel", "TestOAuth", "https://avatars.githubusercontent.com/bar", "joe@test.com", "https://legalinfo.foobar.com", "1.0.0");
         manifest.DescriptionForHuman = "SomeHumanDescription";
         manifest.DescriptionForModel = "SomeModelDescription";
         manifest.Auth = new ManifestNoAuth();

--- a/tests/ApiManifest.Tests/TestFiles/exampleApiManifest.json
+++ b/tests/ApiManifest.Tests/TestFiles/exampleApiManifest.json
@@ -1,0 +1,46 @@
+{
+  "applicationName": "My Application",
+  "publisher": {
+    "name": "Alice",
+    "contactEmail": "alice@example.org"
+  },
+  "apiDependencies": {
+    "moostodon": {
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/APIPatterns/Moostodon/main/spec/tsp-output/%40typespec/openapi3/openapi.yaml",
+      "auth": {
+        "clientIdentifier": "some-uuid-here",
+        "access": [
+          "resourceA.ReadWrite",
+          "resourceB.ReadWrite",
+          "resourceB.Read"
+        ]
+      },
+      "requests": [
+        {
+          "method": "GET",
+          "uriTemplate": "/api/v1/accounts/search"
+        },
+        {
+          "method": "GET",
+          "uriTemplate": "/api/v1/accounts/{id}"
+        }
+      ]
+    },
+    "MicrosoftGraph": {
+      "apiDescriptionUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/DirectoryObjects.yml",
+      "auth": {
+        "clientIdentifier": "some-uuid-here",
+        "access": [
+          "resourceA.ReadWrite",
+          "resourceB.Read"
+        ]
+      },
+      "requests": [
+        {
+          "method": "GET",
+          "uriTemplate": "/directoryObjects/{directoryObject-id}"
+        }
+      ]
+    }
+  }
+}

--- a/tests/ApiManifest.Tests/TestFiles/testOpenApi.yaml
+++ b/tests/ApiManifest.Tests/TestFiles/testOpenApi.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Contoso
+  version: 1.0.0
+tags: []
+paths:
+  /api/v1/activity:
+    post:
+      operationId: contoso_createActivity
+      parameters: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contoso.Activity'
+        '401':
+          description: Access is unauthorized.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Contoso.CreateActivityForm'
+components:
+  schemas:
+    Contoso.Activity:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - name
+    Contoso.CreateActivityForm:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - name
+servers:
+  - url: https://contoso.com/
+    description: Server URL.
+    variables: {}


### PR DESCRIPTION
This PR fixes #4 as a prerequisite for https://github.com/microsoft/OpenAPI.NET/issues/1384 by:
- Adds `ToOpenAIPluginManifestAsync` extension method to a valid instance of `ApiManifestDocument`. The method uses imported logic from Hidi to generate an OpenAI Plugin manifest.
- Adds tests to validate the conversion.
- Adds CHANGELOG.md.
- Adds Mustafa to CODEOWNERS.

### Open Questions:
- Should we allow customers to set `openApiFilePath` parameter (optional) to `ToOpenAIPluginManifestAsync` method? `openApiFilePath` is required to instantiate OpenAI's Plugin manifest `API` property that points to an API specification (file path or URL). Should we instead default to `ApiManifestDocument.ApiDescripionUrl` property instead?
- Should the library make web requests to fetch the OpenAPI document that's used to instantiate `OpenApiManifest`, or should we just expose `ToOpenAIPluginManifest` method that accepts an instance `OpenApiDocument` (customer fetches the OpenApiDocument outside the library)?

### References
- [API Manifest doc](https://www.ietf.org/archive/id/draft-miller-api-manifest-01.html).
- [OpenAI Plugin manifest doc](https://platform.openai.com/docs/plugins/getting-started/plugin-manifest).
- [Existing API manifest to OpenAI Plugin manifest conversion logic in Hidi](https://github.com/microsoft/OpenAPI.NET/blob/d9e7a9ee18f823caeed006178b67db1874800f2d/src/Microsoft.OpenApi.Hidi/OpenApiService.cs#L701).