### PR TITLE
Set lib target framework to netstandard2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2023-12-06
+
+### Added
+
+- Added support for netStandard2.0.
+
 ## [0.5.3] - 2023-11-16
 
 ### Added

--- a/src/lib/AccessRequest.cs
+++ b/src/lib/AccessRequest.cs
@@ -21,7 +21,7 @@ public class AccessRequest
     }
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         if (!String.IsNullOrWhiteSpace(Type)) writer.WriteString(TypeProperty, Type);
         if (Content != null)

--- a/src/lib/ApiDependency.cs
+++ b/src/lib/ApiDependency.cs
@@ -30,7 +30,7 @@ public class ApiDependency
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
 
         if (!string.IsNullOrWhiteSpace(ApiDescriptionUrl)) writer.WriteString(ApiDescriptionUrlProperty, ApiDescriptionUrl);

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -30,7 +30,7 @@ public class ApiManifestDocument
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         Validate();
         writer.WriteStartObject();
         writer.WriteString(ApplicationNameProperty, ApplicationName);

--- a/src/lib/AuthorizationRequirements.cs
+++ b/src/lib/AuthorizationRequirements.cs
@@ -35,7 +35,7 @@ public class AuthorizationRequirements
     // Write Method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
 
         if (!string.IsNullOrWhiteSpace(ClientIdentifier)) writer.WriteString(ClientIdentifierProperty, ClientIdentifier);

--- a/src/lib/Extensions.cs
+++ b/src/lib/Extensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.OpenApi.ApiManifest.Helpers;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -26,7 +27,7 @@ public class Extensions : Dictionary<string, JsonNode?>
 
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         foreach (var extension in this)
         {

--- a/src/lib/Helpers/ValidationHelpers.cs
+++ b/src/lib/Helpers/ValidationHelpers.cs
@@ -32,17 +32,17 @@ namespace Microsoft.OpenApi.ApiManifest.Helpers
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ErrorMessage.BaseUrlIsNotValid, nameof(baseUrl)), parameterName);
         }
 
+        internal static void ThrowIfNull(object? obj, string? paramName = null)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(paramName);
+        }
+
         private static readonly Regex s_emailRegex = new(@"^[^@\s]+@[^@\s]+$", RegexOptions.Compiled, Constants.DefaultRegexTimeout);
         private static void ValidateEmail(string parameterName, string value)
         {
             if (!s_emailRegex.IsMatch(value))
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ErrorMessage.FieldIsNotValid, parameterName), parameterName);
-        }
-
-        public static void ThrowIfNull<T>(T obj, string paramName)
-        {
-            if (obj == null)
-                throw new ArgumentNullException(paramName);
         }
     }
 }

--- a/src/lib/Helpers/ValidationHelpers.cs
+++ b/src/lib/Helpers/ValidationHelpers.cs
@@ -22,13 +22,13 @@ namespace Microsoft.OpenApi.ApiManifest.Helpers
             if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentNullException(parameterName, string.Format(CultureInfo.InvariantCulture, ErrorMessage.FieldIsRequired, parameterName, parentName));
             else
-                ValidateEmail(parameterName, value);
+                ValidateEmail(parameterName, value!);
         }
 
         internal static void ValidateBaseUrl(string parameterName, string? baseUrl)
         {
             // Check if the baseUrl is a valid URL and ends in a slash.
-            if (string.IsNullOrWhiteSpace(baseUrl) || !baseUrl.EndsWith("/", StringComparison.Ordinal) || !Uri.TryCreate(baseUrl, UriKind.Absolute, out _))
+            if (string.IsNullOrWhiteSpace(baseUrl) || !baseUrl!.EndsWith("/", StringComparison.Ordinal) || !Uri.TryCreate(baseUrl, UriKind.Absolute, out _))
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ErrorMessage.BaseUrlIsNotValid, nameof(baseUrl)), parameterName);
         }
 
@@ -37,6 +37,12 @@ namespace Microsoft.OpenApi.ApiManifest.Helpers
         {
             if (!s_emailRegex.IsMatch(value))
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, ErrorMessage.FieldIsNotValid, parameterName), parameterName);
+        }
+
+        public static void ThrowIfNull<T>(T obj, string paramName)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(paramName);
         }
     }
 }

--- a/src/lib/OpenAI/Api.cs
+++ b/src/lib/OpenAI/Api.cs
@@ -46,7 +46,7 @@ public class Api
 
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         Validate(this);
         writer.WriteStartObject();
         writer.WriteString(TypeProperty, Type);

--- a/src/lib/OpenAI/Authentication/BaseManifestAuth.cs
+++ b/src/lib/OpenAI/Authentication/BaseManifestAuth.cs
@@ -36,7 +36,7 @@ public abstract class BaseManifestAuth
     /// <param name="writer">The <see cref="Utf8JsonWriter"/> to use.</param>
     protected void WriteProperties(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteString(TypeProperty, Type);
         if (!string.IsNullOrWhiteSpace(Instructions)) writer.WriteString(InstructionsProperty, Instructions);
     }

--- a/src/lib/OpenAI/Authentication/ManifestNoAuth.cs
+++ b/src/lib/OpenAI/Authentication/ManifestNoAuth.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.OpenApi.ApiManifest.Helpers;
 using System.Text.Json;
 
 namespace Microsoft.OpenApi.ApiManifest.OpenAI.Authentication;
@@ -21,7 +22,7 @@ public class ManifestNoAuth : BaseManifestAuth
 
     public override void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         WriteProperties(writer);
         writer.WriteEndObject();

--- a/src/lib/OpenAI/Authentication/ManifestOAuthAuth.cs
+++ b/src/lib/OpenAI/Authentication/ManifestOAuthAuth.cs
@@ -44,7 +44,7 @@ public class ManifestOAuthAuth : BaseManifestAuth
 
     public override void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         WriteProperties(writer);
         if (!string.IsNullOrWhiteSpace(ClientUrl)) writer.WriteString(ClientUrlPropertyName, ClientUrl);

--- a/src/lib/OpenAI/Authentication/ManifestServiceHttpAuth.cs
+++ b/src/lib/OpenAI/Authentication/ManifestServiceHttpAuth.cs
@@ -39,7 +39,7 @@ public class ManifestServiceHttpAuth : BaseManifestAuth
 
     public override void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         WriteProperties(writer);
         writer.WriteString(AuthorizationTypeProperty, AuthorizationType);

--- a/src/lib/OpenAI/Authentication/ManifestUserHttpAuth.cs
+++ b/src/lib/OpenAI/Authentication/ManifestUserHttpAuth.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.OpenApi.ApiManifest.Helpers;
 using System.Text.Json;
 
 namespace Microsoft.OpenApi.ApiManifest.OpenAI.Authentication;
@@ -30,7 +31,7 @@ public class ManifestUserHttpAuth : BaseManifestAuth
 
     public override void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         WriteProperties(writer);
         writer.WriteString(AuthorizationTypeProperty, AuthorizationType);

--- a/src/lib/OpenAI/Authentication/VerificationTokens.cs
+++ b/src/lib/OpenAI/Authentication/VerificationTokens.cs
@@ -19,7 +19,7 @@ public class VerificationTokens : Dictionary<string, string>
 
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
         foreach (var verificationToken in this)
         {

--- a/src/lib/OpenAI/OpenAIPluginManifest.cs
+++ b/src/lib/OpenAI/OpenAIPluginManifest.cs
@@ -86,7 +86,7 @@ public class OpenAIPluginManifest
     //Write method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         Validate(this);
         writer.WriteStartObject();
         writer.WriteString(SchemaVersionProperty, SchemaVersion);
@@ -138,8 +138,8 @@ public class OpenAIPluginManifest
         ValidationHelpers.ValidateLength(nameof(DescriptionForModel), openAIPluginManifest.DescriptionForModel, 8000);
 
         ValidationHelpers.ValidateNullOrWhitespace(nameof(SchemaVersion), openAIPluginManifest.SchemaVersion, nameof(OpenAIPluginManifest));
-        ArgumentNullException.ThrowIfNull(openAIPluginManifest.Auth);
-        ArgumentNullException.ThrowIfNull(openAIPluginManifest.Api);
+        ValidationHelpers.ThrowIfNull(openAIPluginManifest.Auth, "Auth");
+        ValidationHelpers.ThrowIfNull(openAIPluginManifest.Api, "Api");
         ValidationHelpers.ValidateNullOrWhitespace(nameof(LogoUrl), openAIPluginManifest.LogoUrl, nameof(OpenAIPluginManifest));
         ValidationHelpers.ValidateEmail(nameof(ContactEmail), openAIPluginManifest.ContactEmail, nameof(OpenAIPluginManifest));
         ValidationHelpers.ValidateNullOrWhitespace(nameof(LegalInfoUrl), openAIPluginManifest.LegalInfoUrl, nameof(OpenAIPluginManifest));

--- a/src/lib/Publisher.cs
+++ b/src/lib/Publisher.cs
@@ -26,7 +26,7 @@ public class Publisher
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         Validate();
         writer.WriteStartObject();
         writer.WriteString(NameProperty, Name);

--- a/src/lib/RequestInfo.cs
+++ b/src/lib/RequestInfo.cs
@@ -17,7 +17,7 @@ public class RequestInfo
     // Write method
     public void Write(Utf8JsonWriter writer)
     {
-        ArgumentNullException.ThrowIfNull(writer);
+        ValidationHelpers.ThrowIfNull(writer, nameof(writer));
         writer.WriteStartObject();
 
         if (!String.IsNullOrWhiteSpace(Method)) writer.WriteString(MethodProperty, Method);

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -32,8 +32,10 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             }
             else
             {
-                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency!.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
-                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath ?? apiDependency.ApiDescriptionUrl!);
+                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency?.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(openApiPath))
+                    openApiPath = apiDependency?.ApiDescriptionUrl;
+                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath!);
             }
         }
 

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
         /// <returns>A <see cref="Task{OpenAIPluginManifest}"/></returns>
         public static async Task<OpenAIPluginManifest> ToOpenAIPluginManifestAsync(this ApiManifestDocument apiManifestDocument, string logoUrl, string legalInfoUrl, string? apiDependencyName = default, string? openApiPath = default, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(apiManifestDocument);
+            ValidationHelpers.ThrowIfNull(apiManifestDocument, nameof(apiManifestDocument));
             if (!TryGetApiDependency(apiManifestDocument.ApiDependencies, apiDependencyName, out ApiDependency? apiDependency))
             {
                 throw new ApiManifestException(string.Format(CultureInfo.InvariantCulture, ErrorMessage.ApiDependencyNotFound, nameof(OpenAIPluginManifest)));
@@ -32,8 +32,8 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             }
             else
             {
-                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
-                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath ?? apiDependency.ApiDescriptionUrl);
+                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency!.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
+                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath ?? apiDependency.ApiDescriptionUrl!);
             }
         }
 
@@ -48,8 +48,8 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
         /// <returns>A <see cref="OpenAIPluginManifest"/></returns>
         public static OpenAIPluginManifest ToOpenAIPluginManifest(this ApiManifestDocument apiManifestDocument, OpenApiDocument openApiDocument, string logoUrl, string legalInfoUrl, string openApiPath)
         {
-            ArgumentNullException.ThrowIfNull(apiManifestDocument);
-            ArgumentNullException.ThrowIfNull(openApiDocument);
+            ValidationHelpers.ThrowIfNull(apiManifestDocument, nameof(apiManifestDocument));
+            ValidationHelpers.ThrowIfNull(openApiDocument, nameof(openApiDocument));
             // Validates the ApiManifestDocument before generating the OpenAI manifest. This includes the publisher object.
             apiManifestDocument.Validate();
             string contactEmail = apiManifestDocument.Publisher?.ContactEmail!;
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             if (string.IsNullOrEmpty(apiDependencyName))
                 apiDependency = apiDependencies.FirstOrDefault().Value;
             else
-                _ = apiDependencies.TryGetValue(apiDependencyName, out apiDependency);
+                _ = apiDependencies.TryGetValue(apiDependencyName!, out apiDependency);
             return apiDependency != null;
         }
     }

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -32,9 +32,9 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
             }
             else
             {
-                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency?.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
+                var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency!.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
                 if (string.IsNullOrWhiteSpace(openApiPath))
-                    openApiPath = apiDependency?.ApiDescriptionUrl;
+                    openApiPath = apiDependency.ApiDescriptionUrl;
                 return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath!);
             }
         }

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.OpenApi.ApiManifest</PackageId>
-    <VersionPrefix>0.5.3</VersionPrefix>
+    <VersionPrefix>0.5.4</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Microsoft/OpenApi.ApiManifest</PackageProjectUrl>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -13,7 +13,7 @@
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-	<LangVersion>latest</LangVersion>
+	<LangVersion>10</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -13,7 +13,7 @@
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-	<LangVersion>10</LangVersion>
+    <LangVersion>10</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="[6.0,9.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.OpenApi.ApiManifest</PackageId>
     <VersionPrefix>0.5.3</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
@@ -13,6 +13,7 @@
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
+	<LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>
@@ -30,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR fixes #53 by:
- Changes lib target framework to `netstandard2.0` to be compatible with OpenAPI.NET and Semantic Kernel.
- Sets C# language version to `10` to be compatible with .NET 6, which is supported by Semantic Kernel.
- Addresses changes attributed to the above changes.