### PR TITLE
security/pipeline compliance

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -38,9 +38,9 @@ extends:
         steps:
 
         - task: UseDotNet@2
-          displayName: 'Use .NET 7'
+          displayName: 'Use .NET 8'
           inputs:
-            version: 7.x
+            version: 8.x
 
         - task: UseDotNet@2
           displayName: 'Use .NET 6 (for code signing tasks)'
@@ -68,7 +68,7 @@ extends:
           inputs:
             command: test
             projects: '$(Build.SourcesDirectory)\apimanifest.sln'
-            arguments: '--configuration $(BuildConfiguration) --no-build -f net7.0'
+            arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
 
         - task: EsrpCodeSigning@2
           displayName: 'ESRP DLL CodeSigning'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -30,198 +30,198 @@ extends:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       vmImage: windows-latest
-  stages:
+    stages:
 
-  - stage: build
-    jobs:
-      - job: build
-        steps:
+    - stage: build
+      jobs:
+        - job: build
+          steps:
 
-        - task: UseDotNet@2
-          displayName: 'Use .NET 8'
-          inputs:
-            version: 8.x
+          - task: UseDotNet@2
+            displayName: 'Use .NET 8'
+            inputs:
+              version: 8.x
 
-        - task: UseDotNet@2
-          displayName: 'Use .NET 6 (for code signing tasks)'
-          inputs:
-            packageType: sdk
-            version: 6.x
+          - task: UseDotNet@2
+            displayName: 'Use .NET 6 (for code signing tasks)'
+            inputs:
+              packageType: sdk
+              version: 6.x
 
-        # Install the nuget tool.
-        - task: NuGetToolInstaller@1
-          displayName: 'Install Nuget dependency manager'
-          inputs:
-            versionSpec: '>=5.2.0'
-            checkLatest: true
+          # Install the nuget tool.
+          - task: NuGetToolInstaller@1
+            displayName: 'Install Nuget dependency manager'
+            inputs:
+              versionSpec: '>=5.2.0'
+              checkLatest: true
 
-        # Build the Product project
-        - task: DotNetCoreCLI@2
-          displayName: 'Build APIManifest'
-          inputs:
-            projects: '$(Build.SourcesDirectory)\apimanifest.sln'
-            arguments: '--configuration $(BuildConfiguration) --no-incremental'
+          # Build the Product project
+          - task: DotNetCoreCLI@2
+            displayName: 'Build APIManifest'
+            inputs:
+              projects: '$(Build.SourcesDirectory)\apimanifest.sln'
+              arguments: '--configuration $(BuildConfiguration) --no-incremental'
 
-        # Run the Unit test
-        - task: DotNetCoreCLI@2
-          displayName: 'Test Microsoft.OpenApi.ApiManifest'
-          inputs:
-            command: test
-            projects: '$(Build.SourcesDirectory)\apimanifest.sln'
-            arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
+          # Run the Unit test
+          - task: DotNetCoreCLI@2
+            displayName: 'Test Microsoft.OpenApi.ApiManifest'
+            inputs:
+              command: test
+              projects: '$(Build.SourcesDirectory)\apimanifest.sln'
+              arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
 
-        - task: EsrpCodeSigning@2
-          displayName: 'ESRP DLL CodeSigning'
-          inputs:
-            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-            FolderPath: src
-            Pattern: '**\*Microsoft.OpenApi.ApiManifest.dll'
-            UseMinimatch: true
-            signConfigType: inlineSignParams
-            inlineOperation: |
-              [
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolSign",
-                      "parameters": [
-                      {
-                          "parameterName": "OpusName",
-                          "parameterValue": "Microsoft"
-                      },
-                      {
-                          "parameterName": "OpusInfo",
-                          "parameterValue": "http://www.microsoft.com"
-                      },
-                      {
-                          "parameterName": "FileDigest",
-                          "parameterValue": "/fd \"SHA256\""
-                      },
-                      {
-                          "parameterName": "PageHash",
-                          "parameterValue": "/NPH"
-                      },
-                      {
-                          "parameterName": "TimeStamp",
-                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolVerify",
-                      "parameters": [ ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  }
-              ]
-            SessionTimeout: 20
+          - task: EsrpCodeSigning@2
+            displayName: 'ESRP DLL CodeSigning'
+            inputs:
+              ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+              FolderPath: src
+              Pattern: '**\*Microsoft.OpenApi.ApiManifest.dll'
+              UseMinimatch: true
+              signConfigType: inlineSignParams
+              inlineOperation: |
+                [
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolSign",
+                        "parameters": [
+                        {
+                            "parameterName": "OpusName",
+                            "parameterValue": "Microsoft"
+                        },
+                        {
+                            "parameterName": "OpusInfo",
+                            "parameterValue": "http://www.microsoft.com"
+                        },
+                        {
+                            "parameterName": "FileDigest",
+                            "parameterValue": "/fd \"SHA256\""
+                        },
+                        {
+                            "parameterName": "PageHash",
+                            "parameterValue": "/NPH"
+                        },
+                        {
+                            "parameterName": "TimeStamp",
+                            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                        }
+                        ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    },
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolVerify",
+                        "parameters": [ ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    }
+                ]
+              SessionTimeout: 20
 
-        # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
-        - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/lib/apimanifest.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
-          env:
-            BUILD_CONFIGURATION: $(BuildConfiguration)
-          displayName: Dotnet pack
+          # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+          - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/lib/apimanifest.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+            env:
+              BUILD_CONFIGURATION: $(BuildConfiguration)
+            displayName: Dotnet pack
 
-        - task: PowerShell@2
-          displayName: 'Validate project version has been incremented'
-          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-          inputs:
-            targetType: 'filePath'
-            filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
-            arguments: '-projectPath "$(Build.SourcesDirectory)/src/lib/apimanifest.csproj" -packageName "Microsoft.OpenApi.ApiManifest"'
-            pwsh: true
+          - task: PowerShell@2
+            displayName: 'Validate project version has been incremented'
+            condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
+              arguments: '-projectPath "$(Build.SourcesDirectory)/src/lib/apimanifest.csproj" -packageName "Microsoft.OpenApi.ApiManifest"'
+              pwsh: true
 
-        - task: EsrpCodeSigning@2
-          displayName: 'ESRP CodeSigning Nuget Packages'
-          inputs:
-            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-            FolderPath: '$(Build.ArtifactStagingDirectory)'
-            UseMinimatch: true
-            Pattern: '*.nupkg'
-            signConfigType: inlineSignParams
-            inlineOperation: |
-              [
-                  {
-                      "keyCode": "CP-401405",
-                      "operationSetCode": "NuGetSign",
-                      "parameters": [ ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-401405",
-                      "operationSetCode": "NuGetVerify",
-                      "parameters": [ ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  }
-              ]
-            SessionTimeout: 20
+          - task: EsrpCodeSigning@2
+            displayName: 'ESRP CodeSigning Nuget Packages'
+            inputs:
+              ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+              FolderPath: '$(Build.ArtifactStagingDirectory)'
+              UseMinimatch: true
+              Pattern: '*.nupkg'
+              signConfigType: inlineSignParams
+              inlineOperation: |
+                [
+                    {
+                        "keyCode": "CP-401405",
+                        "operationSetCode": "NuGetSign",
+                        "parameters": [ ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    },
+                    {
+                        "keyCode": "CP-401405",
+                        "operationSetCode": "NuGetVerify",
+                        "parameters": [ ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    }
+                ]
+              SessionTimeout: 20
 
-        - task: CopyFiles@2
-          displayName: 'Copy release scripts to artifact staging directory'
-          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-          inputs:
-            SourceFolder: '$(Build.SourcesDirectory)'
-            Contents: 'scripts\**'
-            TargetFolder: '$(Build.ArtifactStagingDirectory)'
+          - task: CopyFiles@2
+            displayName: 'Copy release scripts to artifact staging directory'
+            condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+            inputs:
+              SourceFolder: '$(Build.SourcesDirectory)'
+              Contents: 'scripts\**'
+              TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-        - task: PublishPipelineArtifact@1
-          displayName: 'Upload Artifact: Nugets'
-          inputs:
-            artifactName: Nugets
-            targetPath: $(Build.ArtifactStagingDirectory)
+          - task: PublishPipelineArtifact@1
+            displayName: 'Upload Artifact: Nugets'
+            inputs:
+              artifactName: Nugets
+              targetPath: $(Build.ArtifactStagingDirectory)
 
-  - stage: deploy
-    condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-    dependsOn: build
-    jobs:
-      - deployment: deploy_openapi_apimanifest
-        dependsOn: []
-        environment: nuget-org
-        strategy:
-          runOnce:
-            deploy:
-              pool:
-                vmImage: ubuntu-latest
-              steps:
-              # Install the nuget tool.
-              - task: NuGetToolInstaller@0
-                displayName: 'Use NuGet >=5.2.0'
-                inputs:
-                  versionSpec: '>=5.2.0'
-                  checkLatest: true
-              - task: DownloadPipelineArtifact@2
-                displayName: Download nupkg from artifacts
-                inputs:
-                  artifact: Nugets
-                  source: current
-              - task: PowerShell@2
-                displayName: 'Extract release information to pipeline'
-                inputs:
-                  targetType: 'filePath'
-                  filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
-                  pwsh: true
-                  arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
-              - task: NuGetCommand@2
-                displayName: 'NuGet push'
-                inputs:
-                  command: push
-                  packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
-                  nuGetFeedType: external
-                  publishFeedCredentials: 'OpenAPI Nuget Connection'
-              - task: GitHubRelease@1
-                displayName: 'GitHub release (create)'
-                inputs:
-                  gitHubConnection: 'Kiota_Release'
-                  target: $(Build.SourceVersion)
-                  tagSource: userSpecifiedTag
-                  tag: 'v$(VERSION_STRING)'
-                  title: '$(VERSION_STRING)'
-                  releaseNotesSource: inline
-                  assets: '!**/**'
-                  changeLogType: issueBased
-                  isPreRelease : '$(IS_PRE_RELEASE)'
-                  addChangeLog : true
+    - stage: deploy
+      condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+      dependsOn: build
+      jobs:
+        - deployment: deploy_openapi_apimanifest
+          dependsOn: []
+          environment: nuget-org
+          strategy:
+            runOnce:
+              deploy:
+                pool:
+                  vmImage: ubuntu-latest
+                steps:
+                # Install the nuget tool.
+                - task: NuGetToolInstaller@0
+                  displayName: 'Use NuGet >=5.2.0'
+                  inputs:
+                    versionSpec: '>=5.2.0'
+                    checkLatest: true
+                - task: DownloadPipelineArtifact@2
+                  displayName: Download nupkg from artifacts
+                  inputs:
+                    artifact: Nugets
+                    source: current
+                - task: PowerShell@2
+                  displayName: 'Extract release information to pipeline'
+                  inputs:
+                    targetType: 'filePath'
+                    filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
+                    pwsh: true
+                    arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
+                - task: NuGetCommand@2
+                  displayName: 'NuGet push'
+                  inputs:
+                    command: push
+                    packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
+                    nuGetFeedType: external
+                    publishFeedCredentials: 'OpenAPI Nuget Connection'
+                - task: GitHubRelease@1
+                  displayName: 'GitHub release (create)'
+                  inputs:
+                    gitHubConnection: 'Kiota_Release'
+                    target: $(Build.SourceVersion)
+                    tagSource: userSpecifiedTag
+                    tag: 'v$(VERSION_STRING)'
+                    title: '$(VERSION_STRING)'
+                    releaseNotesSource: inline
+                    assets: '!**/**'
+                    changeLogType: issueBased
+                    isPreRelease : '$(IS_PRE_RELEASE)'
+                    addChangeLog : true

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -10,263 +10,218 @@ trigger:
 
 pr: none
 
-pool:
-  name: Azure Pipelines
-  vmImage: windows-latest
-
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   ProductBinPath: '$(Build.SourcesDirectory)\src\lib\bin\$(BuildConfiguration)'
 
 
-stages:
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-- stage: build
-  jobs:
-    - job: build
-      steps:
 
-      - task: UseDotNet@2
-        displayName: 'Use .NET 7'
-        inputs:
-          version: 7.x
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      vmImage: windows-latest
+  stages:
 
-      - task: UseDotNet@2
-        displayName: 'Use .NET 6 (for code signing tasks)'
-        inputs:
-          packageType: sdk
-          version: 6.x
+  - stage: build
+    jobs:
+      - job: build
+        steps:
 
-      - task: PoliCheck@2
-        displayName: 'Run PoliCheck "/src"'
-        inputs:
-          inputType: CmdLine
-          cmdLineArgs: '/F:$(Build.SourcesDirectory)/src /T:9 /Sev:"1|2" /PE:2 /O:poli_result_src.xml'
+        - task: UseDotNet@2
+          displayName: 'Use .NET 7'
+          inputs:
+            version: 7.x
 
-      - task: PoliCheck@2
-        displayName: 'Run PoliCheck "/src/tests"'
-        inputs:
-          inputType: CmdLine
-          cmdLineArgs: '/F:$(Build.SourcesDirectory)/src/tests /T:9 /Sev:"1|2" /PE:2 /O:poli_result_test.xml'
+        - task: UseDotNet@2
+          displayName: 'Use .NET 6 (for code signing tasks)'
+          inputs:
+            packageType: sdk
+            version: 6.x
 
-      # Install the nuget tool.
-      - task: NuGetToolInstaller@1
-        displayName: 'Install Nuget dependency manager'
-        inputs:
-          versionSpec: '>=5.2.0'
-          checkLatest: true
+        # Install the nuget tool.
+        - task: NuGetToolInstaller@1
+          displayName: 'Install Nuget dependency manager'
+          inputs:
+            versionSpec: '>=5.2.0'
+            checkLatest: true
 
-      # Build the Product project
-      - task: DotNetCoreCLI@2
-        displayName: 'Build APIManifest'
-        inputs:
-          projects: '$(Build.SourcesDirectory)\apimanifest.sln'
-          arguments: '--configuration $(BuildConfiguration) --no-incremental'
+        # Build the Product project
+        - task: DotNetCoreCLI@2
+          displayName: 'Build APIManifest'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\apimanifest.sln'
+            arguments: '--configuration $(BuildConfiguration) --no-incremental'
 
-      # Run the Unit test
-      - task: DotNetCoreCLI@2
-        displayName: 'Test Microsoft.OpenApi.ApiManifest'
-        inputs:
-          command: test
-          projects: '$(Build.SourcesDirectory)\apimanifest.sln'
-          arguments: '--configuration $(BuildConfiguration) --no-build -f net7.0'
+        # Run the Unit test
+        - task: DotNetCoreCLI@2
+          displayName: 'Test Microsoft.OpenApi.ApiManifest'
+          inputs:
+            command: test
+            projects: '$(Build.SourcesDirectory)\apimanifest.sln'
+            arguments: '--configuration $(BuildConfiguration) --no-build -f net7.0'
 
-      # CredScan
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-        displayName: 'Run CredScan - Src'
-        inputs:
-          toolMajorVersion: 'V2'
-          scanFolder: '$(Build.SourcesDirectory)\src'
-          debugMode: false
+        - task: EsrpCodeSigning@2
+          displayName: 'ESRP DLL CodeSigning'
+          inputs:
+            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+            FolderPath: src
+            Pattern: '**\*Microsoft.OpenApi.ApiManifest.dll'
+            UseMinimatch: true
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-230012",
+                      "operationSetCode": "SigntoolSign",
+                      "parameters": [
+                      {
+                          "parameterName": "OpusName",
+                          "parameterValue": "Microsoft"
+                      },
+                      {
+                          "parameterName": "OpusInfo",
+                          "parameterValue": "http://www.microsoft.com"
+                      },
+                      {
+                          "parameterName": "FileDigest",
+                          "parameterValue": "/fd \"SHA256\""
+                      },
+                      {
+                          "parameterName": "PageHash",
+                          "parameterValue": "/NPH"
+                      },
+                      {
+                          "parameterName": "TimeStamp",
+                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      }
+                      ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-230012",
+                      "operationSetCode": "SigntoolVerify",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            SessionTimeout: 20
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-        displayName: 'Run CredScan - Test'
-        inputs:
-          toolMajorVersion: 'V2'
-          scanFolder: '$(Build.SourcesDirectory)\tests'
-          debugMode: false
+        # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+        - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/lib/apimanifest.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+          env:
+            BUILD_CONFIGURATION: $(BuildConfiguration)
+          displayName: Dotnet pack
 
-      - task: AntiMalware@3
-        displayName: 'Run MpCmdRun.exe - ProductBinPath'
-        inputs:
-          FileDirPath: '$(ProductBinPath)'
-        enabled: false
+        - task: PowerShell@2
+          displayName: 'Validate project version has been incremented'
+          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+          inputs:
+            targetType: 'filePath'
+            filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
+            arguments: '-projectPath "$(Build.SourcesDirectory)/src/lib/apimanifest.csproj" -packageName "Microsoft.OpenApi.ApiManifest"'
+            pwsh: true
 
-      - task: BinSkim@4
-        displayName: 'Run BinSkim - Product Binaries'
-        inputs:
-          InputType: Basic
-          AnalyzeTargetGlob: '$(ProductBinPath)\**\Microsoft.OpenApi.ApiManifest.dll'
-          AnalyzeSymPath: '$(ProductBinPath)'
-          AnalyzeVerbose: true
-          AnalyzeHashes: true
-          AnalyzeEnvironment: true
+        - task: EsrpCodeSigning@2
+          displayName: 'ESRP CodeSigning Nuget Packages'
+          inputs:
+            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+            FolderPath: '$(Build.ArtifactStagingDirectory)'
+            UseMinimatch: true
+            Pattern: '*.nupkg'
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetSign",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetVerify",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            SessionTimeout: 20
 
-      - task: PublishSecurityAnalysisLogs@3
-        displayName: 'Publish Security Analysis Logs'
-        inputs:
-          ArtifactName: SecurityLogs
+        - task: CopyFiles@2
+          displayName: 'Copy release scripts to artifact staging directory'
+          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)'
+            Contents: 'scripts\**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-      - task: PostAnalysis@2
-        displayName: 'Post Analysis'
-        inputs:
-          BinSkim: true
-          CredScan: true
-          PoliCheck: true
+        - task: PublishPipelineArtifact@1
+          displayName: 'Upload Artifact: Nugets'
+          inputs:
+            artifactName: Nugets
+            targetPath: $(Build.ArtifactStagingDirectory)
 
-      - task: EsrpCodeSigning@2
-        displayName: 'ESRP DLL CodeSigning'
-        inputs:
-          ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-          FolderPath: src
-          Pattern: '**\*Microsoft.OpenApi.ApiManifest.dll'
-          UseMinimatch: true
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-                {
-                    "keyCode": "CP-230012",
-                    "operationSetCode": "SigntoolSign",
-                    "parameters": [
-                    {
-                        "parameterName": "OpusName",
-                        "parameterValue": "Microsoft"
-                    },
-                    {
-                        "parameterName": "OpusInfo",
-                        "parameterValue": "http://www.microsoft.com"
-                    },
-                    {
-                        "parameterName": "FileDigest",
-                        "parameterValue": "/fd \"SHA256\""
-                    },
-                    {
-                        "parameterName": "PageHash",
-                        "parameterValue": "/NPH"
-                    },
-                    {
-                        "parameterName": "TimeStamp",
-                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                    }
-                    ],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
-                },
-                {
-                    "keyCode": "CP-230012",
-                    "operationSetCode": "SigntoolVerify",
-                    "parameters": [ ],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
-                }
-            ]
-          SessionTimeout: 20
-
-      # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
-      - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/lib/apimanifest.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
-        env:
-          BUILD_CONFIGURATION: $(BuildConfiguration)
-        displayName: Dotnet pack
-
-      - task: PowerShell@2
-        displayName: 'Validate project version has been incremented'
-        condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-        inputs:
-          targetType: 'filePath'
-          filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
-          arguments: '-projectPath "$(Build.SourcesDirectory)/src/lib/apimanifest.csproj" -packageName "Microsoft.OpenApi.ApiManifest"'
-          pwsh: true
-
-      - task: EsrpCodeSigning@2
-        displayName: 'ESRP CodeSigning Nuget Packages'
-        inputs:
-          ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-          FolderPath: '$(Build.ArtifactStagingDirectory)'
-          UseMinimatch: true
-          Pattern: '*.nupkg'
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-                {
-                    "keyCode": "CP-401405",
-                    "operationSetCode": "NuGetSign",
-                    "parameters": [ ],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
-                },
-                {
-                    "keyCode": "CP-401405",
-                    "operationSetCode": "NuGetVerify",
-                    "parameters": [ ],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
-                }
-            ]
-          SessionTimeout: 20
-
-      - task: CopyFiles@2
-        displayName: 'Copy release scripts to artifact staging directory'
-        condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)'
-          Contents: 'scripts\**'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-      - task: PublishPipelineArtifact@1
-        displayName: 'Upload Artifact: Nugets'
-        inputs:
-          artifactName: Nugets
-          targetPath: $(Build.ArtifactStagingDirectory)
-
-- stage: deploy
-  condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-  dependsOn: build
-  jobs:
-    - deployment: deploy_openapi_apimanifest
-      dependsOn: []
-      environment: nuget-org
-      strategy:
-        runOnce:
-          deploy:
-            pool:
-              vmImage: ubuntu-latest
-            steps:
-            # Install the nuget tool.
-            - task: NuGetToolInstaller@0
-              displayName: 'Use NuGet >=5.2.0'
-              inputs:
-                versionSpec: '>=5.2.0'
-                checkLatest: true
-            - task: DownloadPipelineArtifact@2
-              displayName: Download nupkg from artifacts
-              inputs:
-                artifact: Nugets
-                source: current
-            - task: PowerShell@2
-              displayName: 'Extract release information to pipeline'
-              inputs:
-                targetType: 'filePath'
-                filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
-                pwsh: true
-                arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
-            - task: NuGetCommand@2
-              displayName: 'NuGet push'
-              inputs:
-                command: push
-                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
-                nuGetFeedType: external
-                publishFeedCredentials: 'OpenAPI Nuget Connection'
-            - task: GitHubRelease@1
-              displayName: 'GitHub release (create)'
-              inputs:
-                gitHubConnection: 'Kiota_Release'
-                target: $(Build.SourceVersion)
-                tagSource: userSpecifiedTag
-                tag: 'v$(VERSION_STRING)'
-                title: '$(VERSION_STRING)'
-                releaseNotesSource: inline
-                assets: '!**/**'
-                changeLogType: issueBased
-                isPreRelease : '$(IS_PRE_RELEASE)'
-                addChangeLog : true
+  - stage: deploy
+    condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+    dependsOn: build
+    jobs:
+      - deployment: deploy_openapi_apimanifest
+        dependsOn: []
+        environment: nuget-org
+        strategy:
+          runOnce:
+            deploy:
+              pool:
+                vmImage: ubuntu-latest
+              steps:
+              # Install the nuget tool.
+              - task: NuGetToolInstaller@0
+                displayName: 'Use NuGet >=5.2.0'
+                inputs:
+                  versionSpec: '>=5.2.0'
+                  checkLatest: true
+              - task: DownloadPipelineArtifact@2
+                displayName: Download nupkg from artifacts
+                inputs:
+                  artifact: Nugets
+                  source: current
+              - task: PowerShell@2
+                displayName: 'Extract release information to pipeline'
+                inputs:
+                  targetType: 'filePath'
+                  filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
+                  pwsh: true
+                  arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
+              - task: NuGetCommand@2
+                displayName: 'NuGet push'
+                inputs:
+                  command: push
+                  packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
+                  nuGetFeedType: external
+                  publishFeedCredentials: 'OpenAPI Nuget Connection'
+              - task: GitHubRelease@1
+                displayName: 'GitHub release (create)'
+                inputs:
+                  gitHubConnection: 'Kiota_Release'
+                  target: $(Build.SourceVersion)
+                  tagSource: userSpecifiedTag
+                  tag: 'v$(VERSION_STRING)'
+                  title: '$(VERSION_STRING)'
+                  releaseNotesSource: inline
+                  assets: '!**/**'
+                  changeLogType: issueBased
+                  isPreRelease : '$(IS_PRE_RELEASE)'
+                  addChangeLog : true

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -205,11 +205,12 @@ extends:
                     filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
                     pwsh: true
                     arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
-                - output: nuget
+                - task: 1ES.PublishNuget@1
                   displayName: 'NuGet push'
-                  packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
-                  nuGetFeedType: external
-                  publishFeedCredentials: 'OpenAPI Nuget Connection'
+                  inputs:
+                    packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
+                    nuGetFeedType: external
+                    publishFeedCredentials: 'OpenAPI Nuget Connection'
                 - task: GitHubRelease@1
                   displayName: 'GitHub release (create)'
                   inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -205,13 +205,11 @@ extends:
                     filePath: $(Pipeline.Workspace)\Nugets\scripts\GetNugetPackageVersion.ps1
                     pwsh: true
                     arguments: '-packageDirPath "$(Pipeline.Workspace)/Nugets/"'
-                - task: NuGetCommand@2
+                - output: nuget
                   displayName: 'NuGet push'
-                  inputs:
-                    command: push
-                    packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
-                    nuGetFeedType: external
-                    publishFeedCredentials: 'OpenAPI Nuget Connection'
+                  packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.ApiManifest.*.nupkg'
+                  nuGetFeedType: external
+                  publishFeedCredentials: 'OpenAPI Nuget Connection'
                 - task: GitHubRelease@1
                   displayName: 'GitHub release (create)'
                   inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -168,7 +168,7 @@ extends:
               Contents: 'scripts\**'
               TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-          - task: PublishPipelineArtifact@1
+          - task: 1ES.PublishPipelineArtifact@1
             displayName: 'Upload Artifact: Nugets'
             inputs:
               artifactName: Nugets

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,26 +1,26 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/benchmark/bin/Debug/net7.0/benchmark.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/src/tests",
-            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/src/benchmark/bin/Debug/net8.0/benchmark.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/src/tests",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
 }

--- a/src/benchmark/benchmark.csproj
+++ b/src/benchmark/benchmark.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/benchmark/benchmark.csproj
+++ b/src/benchmark/benchmark.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tool/tool.csproj
+++ b/src/tool/tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
+++ b/tests/ApiManifest.Tests/ApiManifest.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>


### PR DESCRIPTION
- - migrates to the compliant pipeline template for ADO
- - moves to net8 to stay on a supported release
- - temporarily enables PR trigger to validate the pipeline is working
