### PR TITLE
- fixes dependencies casing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixes a bug where the api dependencies would be deduplicated if they had the same key with different casing.
+
 ## [0.5.4] - 2023-12-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Fixes a bug where the api dependencies would be deduplicated if they had the same key with different casing.
+## [0.5.5] - 2024-03-06
+
+### Changed
+
+- Fixed a bug where the api dependencies would be deduplicated if they had the same key with different casing.
 
 ## [0.5.4] - 2023-12-06
 

--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -82,6 +82,6 @@ public class ApiManifestDocument
 
 public class ApiDependencies : Dictionary<string, ApiDependency>
 {
-    public ApiDependencies(IDictionary<string, ApiDependency> dictionary) : base(dictionary, StringComparer.OrdinalIgnoreCase) { }
-    public ApiDependencies() : base(StringComparer.OrdinalIgnoreCase) { }
+    public ApiDependencies(IDictionary<string, ApiDependency> dictionary) : base(dictionary, StringComparer.Ordinal) { }
+    public ApiDependencies() : base(StringComparer.Ordinal) { }
 }

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.OpenApi.ApiManifest</PackageId>
-    <VersionPrefix>0.5.4</VersionPrefix>
+    <VersionPrefix>0.5.5</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Microsoft/OpenApi.ApiManifest</PackageProjectUrl>

--- a/tests/ApiManifest.Tests/BasicTests.cs
+++ b/tests/ApiManifest.Tests/BasicTests.cs
@@ -68,6 +68,14 @@ public class BasicTests
         Assert.Equal(exampleApiManifest.ApiDependencies["example"]?.Extensions?["example-API-dependency-extension"]?.ToString(), apiManifest.ApiDependencies["example"]?.Extensions?["example-api-dependency-extension"]?.ToString());
     }
 
+    [Fact]
+    public void AcceptsMultipleDependenciesWithDifferentCasing()
+    {
+        var document = new ApiManifestDocument("foo");
+        document.ApiDependencies.Add("bar", new());
+        document.ApiDependencies.Add("BAR", new());
+        Assert.Equal(2, document.ApiDependencies.Count);
+    }
 
     // Create an empty document
     [Fact]

--- a/tests/ApiManifest.Tests/BasicTests.cs
+++ b/tests/ApiManifest.Tests/BasicTests.cs
@@ -25,16 +25,16 @@ public class BasicTests
     [Fact]
     public void SerializeDocument()
     {
-        var stream = new MemoryStream();
-        var writer = new Utf8JsonWriter(stream);
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
         exampleApiManifest.Write(writer);
         writer.Flush();
         // Read string from stream
         stream.Position = 0;
-        var reader = new StreamReader(stream);
+        using var reader = new StreamReader(stream);
         var json = reader.ReadToEnd();
         Debug.WriteLine(json);
-        var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(json);
         Assert.NotNull(doc);
         Assert.Equal("application-name", doc.RootElement.GetProperty("applicationName").GetString());
         Assert.Equal("Microsoft", doc.RootElement.GetProperty("publisher").GetProperty("name").GetString());
@@ -44,15 +44,15 @@ public class BasicTests
     [Fact]
     public void DeserializeDocument()
     {
-        var stream = new MemoryStream();
-        var writer = new Utf8JsonWriter(stream);
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
         exampleApiManifest.Write(writer);
         writer.Flush();
         // Read string from stream
         stream.Position = 0;
-        var reader = new StreamReader(stream);
+        using var reader = new StreamReader(stream);
         var json = reader.ReadToEnd();
-        var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(json);
         var apiManifest = ApiManifestDocument.Load(doc.RootElement);
         Assert.Equivalent(exampleApiManifest.Publisher, apiManifest.Publisher);
         Assert.Equivalent(exampleApiManifest.ApiDependencies["example"].Requests, apiManifest.ApiDependencies["example"].Requests);
@@ -75,6 +75,40 @@ public class BasicTests
         document.ApiDependencies.Add("bar", new());
         document.ApiDependencies.Add("BAR", new());
         Assert.Equal(2, document.ApiDependencies.Count);
+    }
+    [Fact]
+    public void DeserializesMultipleDependenciesWithDifferentCasing()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        var document = new ApiManifestDocument("foo");
+        document.ApiDependencies.Add("bar", new()
+        {
+            Requests = [
+                new() {
+                    UriTemplate = "/foo/bar",
+                    Method = "GET"
+                }
+            ]
+        });
+        document.ApiDependencies.Add("BAR", new()
+        {
+            Requests = [
+                new() {
+                    UriTemplate = "/foo/bar",
+                    Method = "GET"
+                }
+            ]
+        });
+        document.Write(writer);
+        writer.Flush();
+        // Read string from stream
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+        using var doc = JsonDocument.Parse(json);
+        var apiManifest = ApiManifestDocument.Load(doc.RootElement);
+        Assert.Equal(2, apiManifest.ApiDependencies.Count);
     }
 
     // Create an empty document


### PR DESCRIPTION
related https://github.com/darrelmiller/api-manifest/issues/15 Since the spec doesn't have any restriction around duplicate keys with different casing, we have to assume it's allowed