### PR TITLE
chore: migrates to OpenAPI.net 2.0 feat: adds support for OAS 3.1

### DIFF
--- a/src/lib/Helpers/ParsingHelpers.cs
+++ b/src/lib/Helpers/ParsingHelpers.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using System.Diagnostics;
 using System.Text.Json;
@@ -150,12 +152,13 @@ internal static class ParsingHelpers
 
     internal static async Task<ReadResult> ParseOpenApiAsync(Stream stream, Uri openApiFileUri, bool inlineExternal, CancellationToken cancellationToken)
     {
-        ReadResult result = await new OpenApiStreamReader(new OpenApiReaderSettings
+        OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
+        OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yml, new OpenApiYamlReader());
+        ReadResult result = await OpenApiDocument.LoadAsync(stream, settings: new OpenApiReaderSettings
         {
             LoadExternalRefs = inlineExternal,
             BaseUrl = openApiFileUri
-        }
-        ).ReadAsync(stream, cancellationToken).ConfigureAwait(false);
+        }, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return result;
     }

--- a/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
+++ b/src/lib/TypeExtensions/ApiManifestDocumentExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OpenApi.ApiManifest.TypeExtensions
                 var result = await ParsingHelpers.ParseOpenApiAsync(new Uri(apiDependency!.ApiDescriptionUrl), false, cancellationToken).ConfigureAwait(false);
                 if (string.IsNullOrWhiteSpace(openApiPath))
                     openApiPath = apiDependency.ApiDescriptionUrl;
-                return apiManifestDocument.ToOpenAIPluginManifest(result.OpenApiDocument, logoUrl, legalInfoUrl, openApiPath!);
+                return apiManifestDocument.ToOpenAIPluginManifest(result.Document, logoUrl, legalInfoUrl, openApiPath!);
             }
         }
 

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.OpenApi.ApiManifest</PackageId>
-    <VersionPrefix>0.5.6</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix>preview</VersionSuffix>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Microsoft/OpenApi.ApiManifest</PackageProjectUrl>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="2.0.0-preview3" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="2.0.0-preview4" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/lib/apimanifest.csproj
+++ b/src/lib/apimanifest.csproj
@@ -30,16 +30,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="2.0.0-preview3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- The target application is the one which will resolve the correct version.
-     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
-    <PackageReference Include="System.Text.Json" Version="[6.0,)" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+    <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
   </ItemGroup>
 
 </Project>

--- a/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
+++ b/tests/ApiManifest.Tests/Helpers/ParsingHelpersTests.cs
@@ -119,8 +119,8 @@ namespace Microsoft.OpenApi.ApiManifest.Tests.Helpers
             var testOpenApiFilePath = Path.Combine(".", "TestFiles", "testOpenApi.yaml");
             using var stream = File.OpenRead(testOpenApiFilePath);
             var results = await ParsingHelpers.ParseOpenApiAsync(stream, new Uri("https://contoso.com/openapi.yaml"), false, CancellationToken.None);
-            Assert.Empty(results.OpenApiDiagnostic.Errors);
-            Assert.NotNull(results.OpenApiDocument);
+            Assert.Empty(results.Diagnostic.Errors);
+            Assert.NotNull(results.Document);
         }
 
         [Fact]

--- a/tests/ApiManifest.Tests/TypeExtensions/OpenApiDocumentExtensionsTests.cs
+++ b/tests/ApiManifest.Tests/TypeExtensions/OpenApiDocumentExtensionsTests.cs
@@ -61,7 +61,9 @@ namespace Microsoft.OpenApi.ApiManifest.Tests.TypeExtensions
             Assert.Equal("GraphAPI", apiManifest.ApiDependencies.First().Key);
             Assert.Equal(apiDescriptionUrl, apiManifest.ApiDependencies.First().Value.ApiDescriptionUrl);
             Assert.Equal(exampleDocument.Info.Version, apiManifest.ApiDependencies.First().Value.ApiDescriptionVersion);
-            Assert.Equal(exampleDocument.Servers.First().Url, apiManifest.ApiDependencies.First().Value.ApiDeploymentBaseUrl);
+            Assert.NotNull(exampleDocument.Servers);
+            Assert.NotEmpty(exampleDocument.Servers);
+            Assert.Equal(exampleDocument.Servers[0].Url, apiManifest.ApiDependencies.First().Value.ApiDeploymentBaseUrl);
             Assert.Equal(exampleDocument.Paths.Count, apiManifest.ApiDependencies.First().Value.Requests.Count);
         }
 
@@ -87,7 +89,9 @@ namespace Microsoft.OpenApi.ApiManifest.Tests.TypeExtensions
             Assert.Equal(apiDependencyName, apiManifest.ApiDependencies.First().Key);
             Assert.Equal(apiDescriptionUrl, apiManifest.ApiDependencies.First().Value.ApiDescriptionUrl);
             Assert.Equal(exampleDocument.Info.Version, apiManifest.ApiDependencies.First().Value.ApiDescriptionVersion);
-            Assert.Equal(exampleDocument.Servers.First().Url, apiManifest.ApiDependencies.First().Value.ApiDeploymentBaseUrl);
+            Assert.NotNull(exampleDocument.Servers);
+            Assert.NotEmpty(exampleDocument.Servers);
+            Assert.Equal(exampleDocument.Servers[0].Url, apiManifest.ApiDependencies.First().Value.ApiDeploymentBaseUrl);
             Assert.Equal(exampleDocument.Paths.Count, apiManifest.ApiDependencies.First().Value.Requests.Count);
         }
 


### PR DESCRIPTION
related https://github.com/microsoft/kiota/pull/5936