### PR TITLE
Issue 156 (add description property)

### DIFF
--- a/src/lib/ApiManifestDocument.cs
+++ b/src/lib/ApiManifestDocument.cs
@@ -7,17 +7,26 @@ public class ApiManifestDocument
 {
     public Publisher? Publisher { get; set; }
     public string? ApplicationName { get; set; }
+    public string? Description { get; set; }
     public ApiDependencies ApiDependencies { get; set; } = new ApiDependencies();
     public Extensions Extensions { get; set; } = new Extensions();
 
     private const string PublisherProperty = "publisher";
     private const string ApplicationNameProperty = "applicationName";
+    private const string DescriptionProperty = "description";
     private const string ApiDependenciesProperty = "apiDependencies";
     private const string ExtensionsProperty = "extensions";
 
     public ApiManifestDocument(string applicationName)
     {
         ApplicationName = applicationName;
+        Validate();
+    }
+
+    public ApiManifestDocument(string applicationName, string description)
+    {
+        ApplicationName = applicationName;
+        Description = description;
         Validate();
     }
 
@@ -34,6 +43,10 @@ public class ApiManifestDocument
         Validate();
         writer.WriteStartObject();
         writer.WriteString(ApplicationNameProperty, ApplicationName);
+        if (Description != null)
+        {
+            writer.WriteString(DescriptionProperty, Description);
+        }
         if (Publisher != null)
         {
             writer.WritePropertyName(PublisherProperty);
@@ -74,6 +87,7 @@ public class ApiManifestDocument
     private static readonly FixedFieldMap<ApiManifestDocument> handlers = new()
     {
         { ApplicationNameProperty, (o,v) => {o.ApplicationName = v.GetString(); } },
+        { DescriptionProperty, (o,v) => {o.Description = v.GetString(); } },
         { PublisherProperty, (o,v) => {o.Publisher = Publisher.Load(v);  } },
         { ApiDependenciesProperty, (o,v) => {o.ApiDependencies = new ApiDependencies(ParsingHelpers.GetMap(v, ApiDependency.Load));  } },
         { ExtensionsProperty, (o,v) => {o.Extensions = Extensions.Load(v);  } }

--- a/tests/ApiManifest.Tests/CreateTests.cs
+++ b/tests/ApiManifest.Tests/CreateTests.cs
@@ -16,6 +16,19 @@ public class CreateTests
         Assert.Null(apiManifest.Publisher);
         Assert.Empty(apiManifest.ApiDependencies);
         Assert.Empty(apiManifest.Extensions);
+        Assert.Null(apiManifest.Description);
+    }
+
+    [Fact]
+    public void CreateApiManifestDocumentWithDescription()
+    {
+        var apiManifest = new ApiManifestDocument("application-name", "description");
+        Assert.NotNull(apiManifest);
+        Assert.Equal("application-name", apiManifest.ApplicationName);
+        Assert.Equal("description", apiManifest.Description);
+        Assert.Null(apiManifest.Publisher);
+        Assert.Empty(apiManifest.ApiDependencies);
+        Assert.Empty(apiManifest.Extensions);
     }
 
     [Theory]

--- a/tests/ApiManifest.Tests/TestFiles/exampleApiManifest.json
+++ b/tests/ApiManifest.Tests/TestFiles/exampleApiManifest.json
@@ -1,5 +1,6 @@
 {
   "applicationName": "My Application",
+  "description":  "My Description",
   "publisher": {
     "name": "Alice",
     "contactEmail": "alice@example.org"


### PR DESCRIPTION
This PR adds an optional description property to the ApiManifestDocument.
Having a description is usefull when creating plugins from the apimanifest file as the decription can be passed to the plugin description to give the LLM the appropriate context as to what the plugin does. 

See also 
[https://github.com/microsoft/OpenApi.ApiManifest/issues/156](url)
[https://github.com/microsoft/semantic-kernel/issues/11562](url)

The PR includes unittests.

Thank you for considering.
Kind regards
Alexander